### PR TITLE
Task 1: ebook config and media classification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,11 @@ bytesize = {version = "1.1.0", features = ["serde"] }
 chrono = {version = "0.4.25", features= ["serde"] }
 futures = "0.3" 
 html-escape = "0.2.13"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
+lopdf = { version = "0.38", default-features = false }
 mockall = "0.11.3"
 lazy_static = "1.5.0"
+quick-xml = { version = "0.37", features = ["encoding"] }
 rand = "0.8.5"
 regex = "1.7.1"
 reqwest = { version = "0.11.20", features = ["json"] }
@@ -48,6 +51,8 @@ once_cell = "1.21.3"
 log = { version = "0.4", optional = true }
 tauri = { version = "2.5.0", features = ["protocol-asset"], optional = true }
 tauri-plugin-log = { version = "2.0.0-rc", optional = true }
+pdfium-render = { version = "0.8", default-features = false, features = ["pdfium_latest", "image_025", "thread_safe"], optional = true }
+zip = { version = "2.2", default-features = false, features = ["deflate"] }
 
 [lib]
 name = "app_lib"
@@ -67,6 +72,7 @@ strip = true # Ensures debug symbols are removed.
 vlc = []
 ai-descriptions = []
 webserver = []
+pdf-thumbnails = ["dep:pdfium-render"]
 # Default features - include Tauri dependencies when webserver is not enabled
 default = ["tauri", "tauri-plugin-log", "log", "tauri-build"]
 

--- a/src/domain/algorithm/media_kind.rs
+++ b/src/domain/algorithm/media_kind.rs
@@ -1,0 +1,85 @@
+use std::path::Path;
+
+const VIDEO_EXTENSIONS: &[&str] = &[
+    "mp4", "mkv", "avi", "mov", "flv", "wmv", "webm", "m4v", "mpg", "mpeg", "3gp", "3g2", "ts",
+    "vob", "m2ts", "mts", "f4v", "f4p", "f4a", "f4b", "ogv", "ogg", "drc", "gif", "gifv", "mng",
+    "qt", "yuv", "rm", "rmvb", "asf", "amv", "m4p", "mp2", "mpe", "mpv", "m2v", "svi", "mxf",
+    "roq", "nsv",
+];
+
+const BOOK_EXTENSIONS: &[&str] = &["pdf", "epub"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaKind {
+    Video,
+    Book,
+    Unsupported,
+}
+
+pub fn classify_media_kind(path: impl AsRef<Path>) -> MediaKind {
+    let path = path.as_ref();
+    if is_hidden(path) || is_temporary_video(path) {
+        return MediaKind::Unsupported;
+    }
+
+    let Some(extension) = normalized_extension(path) else {
+        return MediaKind::Unsupported;
+    };
+
+    if BOOK_EXTENSIONS.contains(&extension.as_str()) {
+        MediaKind::Book
+    } else if is_video_extension(&extension) {
+        MediaKind::Video
+    } else {
+        MediaKind::Unsupported
+    }
+}
+
+pub(crate) fn is_video_extension(extension: &str) -> bool {
+    VIDEO_EXTENSIONS.contains(&extension.to_ascii_lowercase().as_str())
+}
+
+fn normalized_extension(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+}
+
+fn is_hidden(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.'))
+}
+
+fn is_temporary_video(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.to_ascii_lowercase().ends_with(".tmp.mp4"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_media_kind, MediaKind};
+
+    #[test]
+    fn classifies_pdf_and_epub_as_books_case_insensitively() {
+        assert_eq!(classify_media_kind("novel.pdf"), MediaKind::Book);
+        assert_eq!(classify_media_kind("NOVEL.PDF"), MediaKind::Book);
+        assert_eq!(classify_media_kind("novel.epub"), MediaKind::Book);
+        assert_eq!(classify_media_kind("NOVEL.EPUB"), MediaKind::Book);
+    }
+
+    #[test]
+    fn classifies_existing_video_extensions_as_video() {
+        for file_name in ["clip.mp4", "clip.MKV", "clip.avi", "clip.webm", "clip.mov"] {
+            assert_eq!(classify_media_kind(file_name), MediaKind::Video);
+        }
+    }
+
+    #[test]
+    fn classifies_hidden_and_unrelated_files_as_unsupported() {
+        for file_name in [".hidden.mp4", "cover.jpg", "notes.txt", "README", ".epub"] {
+            assert_eq!(classify_media_kind(file_name), MediaKind::Unsupported);
+        }
+    }
+}

--- a/src/domain/algorithm/mod.rs
+++ b/src/domain/algorithm/mod.rs
@@ -1,17 +1,27 @@
 mod naming;
-mod video_utils;    
+mod media_kind;
+mod video_utils;
 mod series;
 mod html;
 
 pub use naming::{
     generate_display_name, 
     get_collection_and_video_from_path, 
+    get_collection_and_book_from_path,
+    get_collection_and_file_from_rooted_path,
     get_next_version_name, 
     get_collection_from_path,
+    get_book_collection_from_path,
+    get_collection_from_rooted_path,
     title_case,
     replace_extension,
     get_video_url,
     get_thumbnails_url
+};
+
+pub use media_kind::{
+    classify_media_kind,
+    MediaKind,
 };
 
 pub use video_utils::{

--- a/src/domain/algorithm/naming.rs
+++ b/src/domain/algorithm/naming.rs
@@ -1,6 +1,6 @@
-use crate::domain::config::get_movie_dir;
 #[cfg(not(feature = "webserver"))]
 use crate::domain::config::get_thumbnail_dir;
+use crate::domain::config::{get_book_dir, get_movie_dir};
 use mockall::lazy_static;
 use regex::Regex;
 use std::{collections::HashSet, path::{Path, PathBuf}};
@@ -9,7 +9,7 @@ use titlecase::titlecase;
 pub fn replace_extension(path: &str, new_extension: &str) -> String {
     let path_obj = Path::new(path);
     let stem = path_obj.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-    
+
     match path_obj.parent() {
         Some(parent) => parent.join(format!("{}{}", stem, new_extension))
             .to_str()
@@ -96,7 +96,15 @@ pub fn generate_display_name(name: &Option<String>) -> String {
 }
 
 pub fn get_collection_from_path(path: &Path) -> String {
-    let short_path = match path.strip_prefix(&get_movie_dir()) {
+    get_collection_from_rooted_path(path, &get_movie_dir())
+}
+
+pub fn get_book_collection_from_path(path: &Path) -> String {
+    get_collection_from_rooted_path(path, &get_book_dir())
+}
+
+pub fn get_collection_from_rooted_path(path: &Path, root: impl AsRef<Path>) -> String {
+    let short_path = match path.strip_prefix(root.as_ref()) {
         Ok(p) => PathBuf::from(p),
         _ => PathBuf::from(path),
     };
@@ -112,7 +120,18 @@ pub fn get_collection_from_path(path: &Path) -> String {
 }
 
 pub fn get_collection_and_video_from_path(path: &Path) -> (String, String) {
-    let short_path = match path.strip_prefix(&get_movie_dir()) {
+    get_collection_and_file_from_rooted_path(path, &get_movie_dir())
+}
+
+pub fn get_collection_and_book_from_path(path: &Path) -> (String, String) {
+    get_collection_and_file_from_rooted_path(path, &get_book_dir())
+}
+
+pub fn get_collection_and_file_from_rooted_path(
+    path: &Path,
+    root: impl AsRef<Path>,
+) -> (String, String) {
+    let short_path = match path.strip_prefix(root.as_ref()) {
         Ok(p) => PathBuf::from(p),
         _ => PathBuf::from(path),
     };
@@ -136,7 +155,7 @@ pub fn get_collection_and_video_from_path(path: &Path) -> (String, String) {
 pub fn title_case(input: &str) -> String {
     // Define the exception words
     let exceptions: HashSet<&str> = ["of", "in", "the"].iter().cloned().collect();
-    
+
     // Split the input by whitespace into words.
     let words: Vec<&str> = input.split_whitespace().collect();
     let mut result = Vec::with_capacity(words.len());
@@ -281,6 +300,29 @@ mod test {
         assert_eq!(
             get_next_version_name(input_path.to_str().unwrap(), None),
             Some(expected_path.to_str().unwrap().to_string())
+        );
+    }
+
+    #[test]
+    fn collection_helpers_strip_their_configured_roots() {
+        let video_path = Path::new("/library/TV/Season 1/episode.mkv");
+        assert_eq!(
+            get_collection_from_rooted_path(video_path, "/library"),
+            "TV/Season 1"
+        );
+        assert_eq!(
+            get_collection_and_file_from_rooted_path(video_path, "/library"),
+            ("TV/Season 1".to_string(), "episode.mkv".to_string())
+        );
+
+        let book_path = Path::new("/library/books/Fiction/Classics/novel.epub");
+        assert_eq!(
+            get_collection_from_rooted_path(book_path, "/library/books"),
+            "Fiction/Classics"
+        );
+        assert_eq!(
+            get_collection_and_file_from_rooted_path(book_path, "/library/books"),
+            ("Fiction/Classics".to_string(), "novel.epub".to_string())
         );
     }
 }

--- a/src/domain/algorithm/video_utils.rs
+++ b/src/domain/algorithm/video_utils.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 // Assuming these are defined in your codebase:
+use super::media_kind::is_video_extension;
 use crate::domain::traits::Repository;
 use crate::domain::models::VideoDetails;
 
@@ -51,33 +52,18 @@ pub fn skip_file(name: &str) -> bool {
         return true;
     }
 
-    // List of accepted file extensions.
-    let accept_extensions = [
-        "", ".mp4", ".mkv", ".avi", ".mov", ".flv", ".wmv", ".webm",
-        ".m4v", ".mpg", ".mpeg", ".3gp", ".3g2", ".ts", ".vob", ".m2ts",
-        ".mts", ".f4v", ".f4p", ".f4a", ".f4b", ".ogv", ".ogg", ".drc",
-        ".gif", ".gifv", ".mng", ".avi", ".mov", ".qt", ".wmv", ".yuv",
-        ".rm", ".rmvb", ".asf", ".amv", ".mp4", ".m4p", ".m4v", ".mpg",
-        ".mp2", ".mpeg", ".mpe", ".mpv", ".mpg", ".mpeg", ".m2v", ".m4v",
-        ".svi", ".3gp", ".3g2", ".mxf", ".roq", ".nsv", ".flv", ".f4v",
-        ".f4p", ".f4a", ".f4b", 
-        // subtitles
-        //".srt", ".sub", ".idx", ".ass", ".ssa", ".sup", ".vtt", ".ttml", ".dfxp", ".ttx", ".xml", ".sbv", ".usf",
-        //".usm", ".usx", ".usx2", ".usx3", ".usx4", ".usx5", ".usx6", ".usx7", ".usx8", ".usx9", ".usx10"
-    ];
-
     // Convert the file name to lowercase and extract the extension.
     let name_lowercase = name.to_lowercase();
     let file_ext = {
         let path = Path::new(&name_lowercase);
         match path.extension().and_then(|s| s.to_str()) {
-            Some(ext) => format!(".{}", ext),
+            Some(ext) => ext.to_string(),
             None => String::new(),
         }
     };
 
     // If the file extension is one of the accepted ones, don't skip the file.
-    if accept_extensions.iter().any(|&ext| ext == file_ext) {
+    if file_ext.is_empty() || is_video_extension(&file_ext) {
         return false;
     }
 
@@ -120,4 +106,3 @@ mod tests {
         }
     }
 }
-

--- a/src/domain/config.rs
+++ b/src/domain/config.rs
@@ -9,10 +9,12 @@ const DATABASE_MIGRATION_DIR: &str = "DATABASE_MIGRATION_DIR";
 const ENABLE_VLC: &str = "ENABLE_VLC";
 pub const GOOGLE_KEY: &str = "GOOGLE_KEY";
 pub const MOVIE_DIR: &str = "MOVIE_DIR";
+pub const BOOK_DIR: &str = "BOOK_DIR";
 const DOWNLOAD_DIR: &str = "DOWNLOAD_DIR";
 const PIRATE_BAY_PROXY_URL: &str = "PIRATE_BAY_PROXY_URL";
 const DELAY_REAPING_TASKS_SECS: &str = "DELAY_REAPING_TASKS_SECS";
 const THUMBNAIL_DIR: &str = "THUMBNAIL_DIR";
+const BOOK_THUMBNAIL_DIR: &str = "BOOK_THUMBNAIL_DIR";
 const OPENAI_API_KEY: &str = "OPENAI_API_KEY";
 const SHARING_SERVER: &str = "SHARING_SERVER";
 const TELEGRAM_TOKEN: &str = "TELEGRAM_TOKEN";
@@ -28,6 +30,10 @@ const DEFAULT_DOWNLOAD_DIR: &str = ".downloads";
 
 pub fn get_movie_dir() -> String {
     env::var(MOVIE_DIR).expect("MOVIE_DIR environment variable is not set")
+}
+
+pub fn get_book_dir() -> String {
+    env::var(BOOK_DIR).expect("BOOK_DIR environment variable is not set")
 }
 
 pub fn enable_vlc_player() -> bool {
@@ -98,6 +104,13 @@ pub fn get_thumbnail_dir(movie_dir: &str) -> PathBuf {
     }
 }
 
+pub fn get_book_thumbnail_dir(book_dir: &str) -> PathBuf {
+    match env::var(BOOK_THUMBNAIL_DIR) {
+        Ok(dir) => PathBuf::from(dir),
+        _ => PathBuf::from(book_dir).join(".thumbnails"),
+    }
+}
+
 pub fn get_openai_api_key() -> String {
     env::var(OPENAI_API_KEY).unwrap_or_default()
 }
@@ -116,4 +129,64 @@ pub fn  get_telegram_chat_id() -> String {
 
 pub fn get_auth_credentials() -> String {
     env::var(AUTH_CREDENTIALS).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_book_dir, get_book_thumbnail_dir, BOOK_DIR, BOOK_THUMBNAIL_DIR};
+    use std::env;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        originals: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvVarGuard {
+        fn new(names: &[&'static str]) -> Self {
+            Self {
+                originals: names
+                    .iter()
+                    .map(|name| (*name, env::var(name).ok()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.originals.iter() {
+                match value {
+                    Some(value) => env::set_var(name, value),
+                    None => env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn book_dir_is_required_and_thumbnail_dir_defaults_under_book_dir() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::new(&[BOOK_DIR, BOOK_THUMBNAIL_DIR]);
+
+        env::remove_var(BOOK_DIR);
+        env::remove_var(BOOK_THUMBNAIL_DIR);
+        assert!(catch_unwind(AssertUnwindSafe(get_book_dir)).is_err());
+
+        env::set_var(BOOK_DIR, "/library/books");
+        assert_eq!(get_book_dir(), "/library/books");
+        assert_eq!(
+            get_book_thumbnail_dir("/library/books"),
+            PathBuf::from("/library/books/.thumbnails")
+        );
+
+        env::set_var(BOOK_THUMBNAIL_DIR, "/library/book-covers");
+        assert_eq!(
+            get_book_thumbnail_dir("/library/books"),
+            PathBuf::from("/library/book-covers")
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add `BOOK_DIR` and `BOOK_THUMBNAIL_DIR` config helpers for book storage.
- Add a `MediaKind` classifier for videos, PDF/EPUB books, and unsupported files while preserving `skip_file` video behavior.
- Add root-aware collection helpers and book-specific wrappers that strip `BOOK_DIR`.
- Add Rust-native ZIP/XML/image/PDF metadata dependencies and optional Pdfium thumbnail feature wiring.

## Validation
- `cargo test --no-default-features --features webserver --lib`
- `cargo check --no-default-features --features "webserver pdf-thumbnails"`
- `cargo build --no-default-features --features webserver`
- `git diff --check`
- Spec-compliance and code-quality subagent reviews completed.

## Notes
- `cargo test --no-default-features --features webserver` currently fails on `tests/download_test.rs` because `tests/common/server.rs` panics at Axum root nesting; this reproduces on `spec/ebook-support`.
- Default `cargo build` is blocked locally by missing Tauri/GTK pkg-config libraries (`dbus-1` in this worktree; GTK libs on the base checkout), also not introduced by this change.
