### PR TITLE
Ebook support Task 3: book events and local routing

### DIFF
--- a/src/domain/messagebus/local_message_exchange.rs
+++ b/src/domain/messagebus/local_message_exchange.rs
@@ -19,6 +19,7 @@ pub enum MessageFilter {
     All,
     Media,
     Task,
+    Book,
     Video,
     PlayerState,
 }
@@ -52,6 +53,7 @@ impl LocalMessageExchange {
                 (MessageFilter::All, LocalMessageSenderReceiver::new()),
                 (MessageFilter::Media, LocalMessageSenderReceiver::new()),
                 (MessageFilter::Task, LocalMessageSenderReceiver::new()),
+                (MessageFilter::Book, LocalMessageSenderReceiver::new()),
                 (MessageFilter::Video, LocalMessageSenderReceiver::new()),
                 (MessageFilter::PlayerState, LocalMessageSenderReceiver::new()),
             ]
@@ -96,6 +98,7 @@ impl LocalMessageExchange {
         let filter = match &message {
             LocalMessage::Media(_) => Some(MessageFilter::Media),
             LocalMessage::Task(_) => Some(MessageFilter::Task),
+            LocalMessage::Book(_) => Some(MessageFilter::Book),
             LocalMessage::Video(_) => Some(MessageFilter::Video),
             LocalMessage::PlayerState(_) => Some(MessageFilter::PlayerState),
             _ => {
@@ -130,7 +133,8 @@ impl LocalMessageExchange {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::messages::{LocalMessage, MediaEvent};
+    use crate::domain::messages::{BookEvent, LocalMessage, MediaEvent};
+    use crate::domain::models::BookDetails;
     use std::path::PathBuf;
     use tokio::time::timeout;
     use tokio::time::Duration;
@@ -222,5 +226,31 @@ mod tests {
         
         // Task receiver should not get any messages
         assert!(timeout(Duration::from_millis(100), task_receiver.recv()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn book_messages_reach_book_and_all_but_not_video_subscribers() {
+        let exchange = LocalMessageExchange::new();
+        let sender = exchange.new_sender();
+        let mut book_receiver = exchange.listen_for_messages(MessageFilter::Book).await.unwrap();
+        let mut all_receiver = exchange.listen_for_messages(MessageFilter::All).await.unwrap();
+        let mut video_receiver = exchange.listen_for_messages(MessageFilter::Video).await.unwrap();
+        let event = BookEvent::new_book_added_event(BookDetails {
+            checksum: 123,
+            title: "Dune".to_string(),
+            ..BookDetails::default()
+        });
+
+        sender.send(LocalMessage::Book(event)).await.unwrap();
+
+        assert!(matches!(
+            timeout(Duration::from_millis(100), book_receiver.recv()).await,
+            Ok(Ok(LocalMessage::Book(_)))
+        ));
+        assert!(matches!(
+            timeout(Duration::from_millis(100), all_receiver.recv()).await,
+            Ok(Ok(LocalMessage::Book(_)))
+        ));
+        assert!(timeout(Duration::from_millis(100), video_receiver.recv()).await.is_err());
     }
 }

--- a/src/domain/messagebus/message_exchange.rs
+++ b/src/domain/messagebus/message_exchange.rs
@@ -245,6 +245,11 @@ impl MessageExchange {
                 // Broadcast to all clients
                 MessageExchange::broadcast_to_all(client_map, remote_message).await;
             },
+            LocalMessage::Book(book_event) => {
+                let remote_message = RemoteMessage::Book(vec![book_event]);
+
+                MessageExchange::broadcast_to_all(client_map, remote_message).await;
+            },
             LocalMessage::Video(video_event) => {
                 let remote_message = RemoteMessage::Video(vec![video_event.clone()]);
                 
@@ -282,6 +287,77 @@ impl MessageExchange {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::domain::messages::{BookEvent, VideoEvent};
+    use crate::domain::models::BookDetails;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingPlayer {
+        messages: Mutex<Vec<RemoteMessage>>,
+    }
+
+    #[async_trait]
+    impl RemotePlayer for RecordingPlayer {
+        async fn send(&self, message: RemoteMessage) -> Result<StatusCode, SendError> {
+            self.messages.lock().unwrap().push(message);
+            Ok(StatusCode::OK)
+        }
+    }
+
+    #[tokio::test]
+    async fn book_events_are_broadcast_as_structured_remote_messages() {
+        let client_map = Arc::new(RwLock::new(MessengerMap::new()));
+        let player = Arc::new(RecordingPlayer::default());
+        let remote_player: Arc<dyn RemotePlayer> = player.clone();
+        client_map.write().await.add_control("browser".to_string(), remote_player);
+        let event = BookEvent::new_book_changed_event(BookDetails {
+            checksum: 123,
+            title: "Dune".to_string(),
+            ..BookDetails::default()
+        });
+
+        MessageExchange::on_local_message(&client_map, LocalMessage::Book(event)).await;
+
+        let messages = player.messages.lock().unwrap();
+        assert!(matches!(
+            messages.as_slice(),
+            [RemoteMessage::Book(events)]
+                if events.len() == 1 && events[0].checksum == "123"
+        ));
+    }
+
+    #[test]
+    fn book_remote_message_uses_structured_book_envelope() {
+        let message = RemoteMessage::Book(vec![BookEvent::new_book_deleted_event(123)]);
+
+        assert_eq!(
+            serde_json::to_value(message).unwrap(),
+            serde_json::json!({
+                "Book": [{
+                    "type": "BookEventDeleted",
+                    "checksum": "123"
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn existing_video_remote_message_envelope_is_unchanged() {
+        let message = RemoteMessage::Video(vec![VideoEvent::new_video_deleted_event(42)]);
+
+        assert_eq!(
+            serde_json::to_value(message).unwrap(),
+            serde_json::json!({
+                "Video": [{
+                    "type": "VideoEventDeleted",
+                    "checksum": "42"
+                }]
+            })
+        );
+    }
+
     /*use super::*;
     use crate::domain::messages::RemoteMessage;
     use crate::domain::traits::RemotePlayer;

--- a/src/domain/messages/book_event.rs
+++ b/src/domain/messages/book_event.rs
@@ -1,0 +1,90 @@
+use crate::domain::models::BookDetails;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(i32)]
+pub enum BookEventType {
+    BookEventAdded = 0,
+    BookEventChanged = 1,
+    BookEventDeleted = 2,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BookEvent {
+    #[serde(rename = "type")]
+    pub event_type: BookEventType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub book: Option<BookDetails>,
+    pub checksum: String,
+}
+
+impl BookEvent {
+    pub fn new_book_added_event(book: BookDetails) -> Self {
+        Self {
+            event_type: BookEventType::BookEventAdded,
+            checksum: book.checksum.to_string(),
+            book: Some(book),
+        }
+    }
+
+    pub fn new_book_changed_event(book: BookDetails) -> Self {
+        Self {
+            event_type: BookEventType::BookEventChanged,
+            checksum: book.checksum.to_string(),
+            book: Some(book),
+        }
+    }
+
+    pub fn new_book_deleted_event(checksum: i64) -> Self {
+        Self {
+            event_type: BookEventType::BookEventDeleted,
+            book: None,
+            checksum: checksum.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::models::{BookDetails, BookFormat};
+
+    fn sample_book(checksum: i64) -> BookDetails {
+        BookDetails {
+            file_name: "Dune.epub".to_string(),
+            collection: "Science Fiction".to_string(),
+            title: "Dune".to_string(),
+            authors: vec!["Frank Herbert".to_string()],
+            format: BookFormat::Epub,
+            checksum,
+            ..BookDetails::default()
+        }
+    }
+
+    #[test]
+    fn added_event_carries_string_checksum_and_book_payload() {
+        let event = BookEvent::new_book_added_event(sample_book(123));
+
+        assert_eq!(event.event_type, BookEventType::BookEventAdded);
+        assert_eq!(event.checksum, "123");
+        assert_eq!(event.book.unwrap().title, "Dune");
+    }
+
+    #[test]
+    fn changed_event_carries_string_checksum_and_book_payload() {
+        let event = BookEvent::new_book_changed_event(sample_book(456));
+
+        assert_eq!(event.event_type, BookEventType::BookEventChanged);
+        assert_eq!(event.checksum, "456");
+        assert_eq!(event.book.unwrap().title, "Dune");
+    }
+
+    #[test]
+    fn deleted_event_carries_string_checksum_without_book_payload() {
+        let event = BookEvent::new_book_deleted_event(789);
+
+        assert_eq!(event.event_type, BookEventType::BookEventDeleted);
+        assert_eq!(event.checksum, "789");
+        assert!(event.book.is_none());
+    }
+}

--- a/src/domain/messages/local.rs
+++ b/src/domain/messages/local.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 
+use super::book_event::BookEvent;
 use super::messages::{TaskState, RemotePlayerState, RemoteMessage};
 use super::media::MediaEvent;
 use super::video_event::VideoEvent;
@@ -13,6 +14,7 @@ use super::video_event::VideoEvent;
 pub enum LocalMessage {
     Media(MediaEvent),
     Task(Vec<TaskState>),
+    Book(BookEvent),
     Video(VideoEvent),
     PlayerState(RemotePlayerState),
     SendToRemote(SocketAddr, RemoteMessage),

--- a/src/domain/messages/messages.rs
+++ b/src/domain/messages/messages.rs
@@ -5,7 +5,7 @@ use mockall::lazy_static;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::net::{IpAddr, SocketAddr};
 
-use super::VideoEvent;
+use super::{BookEvent, VideoEvent};
 
 lazy_static! {
     static ref DEFAULT_ADDRESS: SocketAddr = SocketAddr::new(IpAddr::from([0, 0, 0, 0]), 80);
@@ -145,6 +145,7 @@ pub enum RemoteMessage {
     LastState(VideoDetails),
     CurrentTasks(Vec<TaskState>),
 
+    Book(Vec<BookEvent>),
     Video(Vec<VideoEvent>),
 }
 

--- a/src/domain/messages/mod.rs
+++ b/src/domain/messages/mod.rs
@@ -1,6 +1,7 @@
 mod messages;
 mod media_messages;
 mod download;
+mod book_event;
 mod video_event;
 mod local;
 mod chat_gpt;
@@ -9,6 +10,7 @@ mod media;
 pub use messages::*;
 //pub use media_messages::*;
 pub use download::*;
+pub use book_event::*;
 pub use video_event::*;
 pub use local::*;
 pub use chat_gpt::*;


### PR DESCRIPTION
## Summary

- add `BookEventType` and `BookEvent` constructors for added, changed, and deleted books
- route `LocalMessage::Book` through dedicated `Book` and shared `All` subscriptions
- broadcast structured book events through the websocket message exchange
- preserve the existing video event envelope with explicit regression coverage

## Why

Task 3 establishes the event and routing contract that later repository and ingestion work will use to notify clients when book records change.

## Impact

Book-aware clients can subscribe to and receive additive book refresh events. Existing media, task, video, and player-state routing behavior and the video websocket payload remain unchanged.

## Verification

- `make test` — 76 unit tests and 7 integration tests passed; 0 failures; 4 ignored
- `git diff --check`
- independent task-scoped and whole-branch reviews found no issues

The repository-wide `cargo fmt --check` still reports pre-existing formatting drift and nightly-only rustfmt settings outside this task; the task diff itself is whitespace-clean.

Closes #38.
Related to #37 (Task 2 prerequisite and the issue supplied with this request).