### PR TITLE
Ebook support Task 4: book repository persistence

### DIFF
--- a/migrations/20260713000001_books.sql
+++ b/migrations/20260713000001_books.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS books (
+    checksum INTEGER PRIMARY KEY NOT NULL,
+    file_name TEXT NOT NULL,
+    collection TEXT NOT NULL,
+    title TEXT NOT NULL,
+    authors TEXT,
+    description TEXT,
+    publisher TEXT,
+    published_date TEXT,
+    language TEXT,
+    isbn TEXT,
+    format TEXT NOT NULL,
+    page_count INTEGER,
+    thumbnail TEXT NOT NULL,
+    metadata TEXT,
+    search_phrase TEXT,
+    state INTEGER DEFAULT 0,
+    created_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_books_collection_file
+    ON books(collection, file_name);
+
+CREATE INDEX IF NOT EXISTS idx_books_title
+    ON books(title);
+
+CREATE INDEX IF NOT EXISTS idx_books_authors
+    ON books(authors);

--- a/src/adaptors/repository.rs
+++ b/src/adaptors/repository.rs
@@ -1,21 +1,16 @@
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
-use sqlx::{Error, Sqlite, Row};
-use sqlx::migrate::{
-    MigrateDatabase, 
-    MigrateError, Migrator
-};
-use sqlx::sqlite::{SqlitePool, SqliteRow};
 use serde_json;
+use sqlx::migrate::{MigrateDatabase, MigrateError, Migrator};
+use sqlx::sqlite::{SqlitePool, SqliteRow};
+use sqlx::{Error, Row, Sqlite};
 
 use crate::domain::algorithm::get_thumbnails_url;
 use crate::domain::config::get_database_migration_dir;
-use crate::domain::messages::{LocalMessage, LocalMessageSender, VideoEvent };
+use crate::domain::messages::{BookEvent, LocalMessage, LocalMessageSender, VideoEvent};
 use crate::domain::models::{
-    CollectionItem, 
-    SeriesDetails, 
-    VideoDetails, 
-    VideoMetadata, 
+    BookDetails, BookFormat, BookMetadata, CollectionItem, SeriesDetails, VideoDetails,
+    VideoMetadata,
 };
 use crate::domain::traits::Databaser;
 use itertools::Itertools;
@@ -26,7 +21,6 @@ pub struct SqlRepository {
     pool: SqlitePool,
     sender: Option<LocalMessageSender>,
 }
-
 
 impl SqlRepository {
     pub async fn new(url: &str, sender: Option<LocalMessageSender>) -> Result<Self, Error> {
@@ -98,11 +92,247 @@ impl SqlRepository {
 
         video_details
     }
-}
 
+    fn book_from_record(row: &SqliteRow) -> BookDetails {
+        let authors = row
+            .get::<Option<String>, _>("authors")
+            .and_then(|value| serde_json::from_str(&value).ok())
+            .unwrap_or_default();
+        let metadata = row
+            .get::<Option<String>, _>("metadata")
+            .and_then(|value| serde_json::from_str::<BookMetadata>(&value).ok())
+            .unwrap_or_default();
+        let format = match row.get::<String, _>("format").as_str() {
+            "epub" => BookFormat::Epub,
+            _ => BookFormat::Pdf,
+        };
+
+        BookDetails {
+            file_name: row.get("file_name"),
+            collection: row.get("collection"),
+            title: row.get("title"),
+            authors,
+            description: row.get("description"),
+            publisher: row.get("publisher"),
+            published_date: row.get("published_date"),
+            language: row.get("language"),
+            isbn: row.get("isbn"),
+            format,
+            page_count: row.get("page_count"),
+            thumbnail: row.get("thumbnail"),
+            metadata,
+            checksum: row.get("checksum"),
+            search_phrase: row.get("search_phrase"),
+            state: row.get::<i32, _>("state").into(),
+            created_on: row.get("created_on"),
+            updated_on: row.get("updated_on"),
+            dir_path: None,
+        }
+    }
+}
 
 #[async_trait]
 impl Databaser for SqlRepository {
+    async fn save_book(&self, details: &BookDetails) -> Result<i64, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+        let is_update = sqlx::query(
+            r#"
+            SELECT 1
+            FROM books
+            WHERE checksum = ? OR (collection = ? AND file_name = ?)
+            "#,
+        )
+        .bind(details.checksum)
+        .bind(&details.collection)
+        .bind(&details.file_name)
+        .fetch_optional(&mut *tx)
+        .await?
+        .is_some();
+        let authors = serde_json::to_string(&details.authors).unwrap_or_default();
+        let metadata = serde_json::to_string(&details.metadata).unwrap_or_default();
+        let format = match details.format {
+            BookFormat::Pdf => "pdf",
+            BookFormat::Epub => "epub",
+        };
+
+        sqlx::query(
+            r#"
+            INSERT INTO books (
+                checksum, file_name, collection, title, authors, description,
+                publisher, published_date, language, isbn, format, page_count,
+                thumbnail, metadata, search_phrase, state
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(collection, file_name) DO UPDATE SET
+                checksum = excluded.checksum,
+                title = excluded.title,
+                authors = excluded.authors,
+                description = excluded.description,
+                publisher = excluded.publisher,
+                published_date = excluded.published_date,
+                language = excluded.language,
+                isbn = excluded.isbn,
+                format = excluded.format,
+                page_count = excluded.page_count,
+                thumbnail = excluded.thumbnail,
+                metadata = excluded.metadata,
+                search_phrase = excluded.search_phrase,
+                state = excluded.state,
+                updated_on = CURRENT_TIMESTAMP
+            ON CONFLICT(checksum) DO UPDATE SET
+                file_name = excluded.file_name,
+                collection = excluded.collection,
+                title = excluded.title,
+                authors = excluded.authors,
+                description = excluded.description,
+                publisher = excluded.publisher,
+                published_date = excluded.published_date,
+                language = excluded.language,
+                isbn = excluded.isbn,
+                format = excluded.format,
+                page_count = excluded.page_count,
+                thumbnail = excluded.thumbnail,
+                metadata = excluded.metadata,
+                search_phrase = excluded.search_phrase,
+                state = excluded.state,
+                updated_on = CURRENT_TIMESTAMP
+            "#,
+        )
+        .bind(details.checksum)
+        .bind(&details.file_name)
+        .bind(&details.collection)
+        .bind(&details.title)
+        .bind(authors)
+        .bind(&details.description)
+        .bind(&details.publisher)
+        .bind(&details.published_date)
+        .bind(&details.language)
+        .bind(&details.isbn)
+        .bind(format)
+        .bind(details.page_count)
+        .bind(&details.thumbnail)
+        .bind(metadata)
+        .bind(&details.search_phrase)
+        .bind(details.state as i32)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        if let Some(sender) = &self.sender {
+            let message = if is_update {
+                LocalMessage::Book(BookEvent::new_book_changed_event(details.clone()))
+            } else {
+                LocalMessage::Book(BookEvent::new_book_added_event(details.clone()))
+            };
+
+            if let Err(error) = sender.send(message).await {
+                tracing::error!("Error sending book event {}", error);
+            }
+        }
+
+        Ok(details.checksum)
+    }
+
+    async fn retrieve_book(&self, checksum: i64) -> Result<BookDetails, sqlx::Error> {
+        let row = sqlx::query("SELECT * FROM books WHERE checksum = ?")
+            .bind(checksum)
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(Self::book_from_record(&row))
+    }
+
+    async fn list_books(&self, collection: &str) -> Result<Vec<BookDetails>, sqlx::Error> {
+        let rows = sqlx::query(
+            r#"
+            SELECT *
+            FROM books
+            WHERE collection = ?
+            ORDER BY title, file_name
+            "#,
+        )
+        .bind(collection)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.iter().map(Self::book_from_record).collect())
+    }
+
+    async fn list_book_collections(
+        &self,
+        parent_collection: &str,
+    ) -> Result<Vec<String>, sqlx::Error> {
+        let rows = if parent_collection.is_empty() {
+            sqlx::query(
+                r#"
+                SELECT DISTINCT collection
+                FROM books
+                WHERE collection <> ''
+                "#,
+            )
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query(
+                r#"
+                SELECT DISTINCT collection
+                FROM books
+                WHERE collection LIKE ?
+                "#,
+            )
+            .bind(format!("{}%", parent_collection))
+            .fetch_all(&self.pool)
+            .await?
+        };
+        let part = if parent_collection.is_empty() {
+            0
+        } else {
+            parent_collection.matches('/').count() + 1
+        };
+
+        Ok(rows
+            .into_iter()
+            .map(|row| row.get::<String, _>("collection"))
+            .filter_map(|collection| collection.split('/').nth(part).map(str::to_string))
+            .unique()
+            .sorted()
+            .collect())
+    }
+
+    async fn list_all_books(&self) -> Result<Vec<BookDetails>, sqlx::Error> {
+        let rows = sqlx::query(
+            r#"
+            SELECT *
+            FROM books
+            ORDER BY collection, title, file_name
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.iter().map(Self::book_from_record).collect())
+    }
+
+    async fn delete_book(&self, checksum: i64) -> Result<u64, sqlx::Error> {
+        let rows_affected = sqlx::query("DELETE FROM books WHERE checksum = ?")
+            .bind(checksum)
+            .execute(&self.pool)
+            .await?
+            .rows_affected();
+
+        if rows_affected > 0 {
+            if let Some(sender) = &self.sender {
+                let message = LocalMessage::Book(BookEvent::new_book_deleted_event(checksum));
+                if let Err(error) = sender.send(message).await {
+                    tracing::error!("Error sending book deleted event {} {}", checksum, error);
+                }
+            }
+        }
+
+        Ok(rows_affected)
+    }
+
     async fn save_video(&self, details: &VideoDetails) -> Result<i64, sqlx::Error> {
         // Use a transaction so the existence check and upsert are atomic
         let mut tx = self.pool.begin().await?;
@@ -558,10 +788,302 @@ impl Databaser for SqlRepository {
 #[cfg(test)]
 mod tests {
     use chrono::Local;
+    use serde_json::json;
 
-    use crate::domain::models::VideoState;
+    use crate::domain::messages::BookEventType;
+    use crate::domain::models::{BookDetails, BookFormat, BookMetadata, BookState, VideoState};
+    use tokio::sync::mpsc;
 
     use super::*;
+
+    fn sample_book(checksum: i64, collection: &str, file_name: &str, title: &str) -> BookDetails {
+        let now = Local::now().naive_local();
+
+        BookDetails {
+            file_name: file_name.to_string(),
+            collection: collection.to_string(),
+            title: title.to_string(),
+            authors: vec!["Ursula K. Le Guin".to_string(), "Translator".to_string()],
+            description: Some("A classic novel".to_string()),
+            publisher: Some("Ace".to_string()),
+            published_date: Some("1969".to_string()),
+            language: Some("en".to_string()),
+            isbn: Some("9780441478125".to_string()),
+            format: BookFormat::Epub,
+            page_count: Some(304),
+            thumbnail: "left-hand-of-darkness.jpg".to_string(),
+            metadata: BookMetadata {
+                raw: Some(json!({
+                    "subjects": ["science fiction", "gender"],
+                    "source": {"kind": "epub"}
+                })),
+                extraction_error: Some("cover missing".to_string()),
+            },
+            checksum,
+            search_phrase: Some("left hand darkness".to_string()),
+            state: BookState::Ready,
+            created_on: now,
+            updated_on: now,
+            dir_path: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn migrations_create_books_table_and_indexes() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+
+        let rows = sqlx::query(
+            r#"
+            SELECT name
+            FROM sqlite_master
+            WHERE type IN ('table', 'index')
+              AND name IN (
+                'books',
+                'idx_books_collection_file',
+                'idx_books_title',
+                'idx_books_authors'
+              )
+            ORDER BY name
+            "#,
+        )
+        .fetch_all(&db.pool)
+        .await
+        .unwrap();
+        let names = rows
+            .iter()
+            .map(|row| row.get::<String, _>("name"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec![
+                "books",
+                "idx_books_authors",
+                "idx_books_collection_file",
+                "idx_books_title",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn save_and_retrieve_book_round_trips_all_fields_and_json() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+        let book = sample_book(
+            101,
+            "Science Fiction",
+            "The Left Hand of Darkness.epub",
+            "The Left Hand of Darkness",
+        );
+
+        assert_eq!(db.save_book(&book).await.unwrap(), book.checksum);
+
+        let retrieved = db.retrieve_book(book.checksum).await.unwrap();
+        let mut expected = book;
+        expected.created_on = retrieved.created_on;
+        expected.updated_on = retrieved.updated_on;
+
+        assert_eq!(retrieved, expected);
+    }
+
+    #[tokio::test]
+    async fn save_book_updates_on_collection_and_file_conflict() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+        let original = sample_book(201, "Fantasy", "Earthsea.epub", "A Wizard of Earthsea");
+        db.save_book(&original).await.unwrap();
+        let mut replacement = sample_book(202, "Fantasy", "Earthsea.epub", "Earthsea");
+        replacement.authors = vec!["Ursula Le Guin".to_string()];
+
+        assert_eq!(
+            db.save_book(&replacement).await.unwrap(),
+            replacement.checksum
+        );
+
+        assert!(matches!(
+            db.retrieve_book(original.checksum).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+        let retrieved = db.retrieve_book(replacement.checksum).await.unwrap();
+        assert_eq!(retrieved.title, replacement.title);
+        assert_eq!(retrieved.authors, replacement.authors);
+    }
+
+    #[tokio::test]
+    async fn save_book_updates_on_checksum_conflict() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+        let original = sample_book(301, "Fantasy", "Earthsea.epub", "Earthsea");
+        db.save_book(&original).await.unwrap();
+        let replacement = sample_book(
+            original.checksum,
+            "Classics/Fantasy",
+            "A Wizard of Earthsea.epub",
+            "A Wizard of Earthsea",
+        );
+
+        assert_eq!(
+            db.save_book(&replacement).await.unwrap(),
+            replacement.checksum
+        );
+
+        let retrieved = db.retrieve_book(original.checksum).await.unwrap();
+        assert_eq!(retrieved.collection, replacement.collection);
+        assert_eq!(retrieved.file_name, replacement.file_name);
+        assert_eq!(retrieved.title, replacement.title);
+    }
+
+    #[tokio::test]
+    async fn save_book_emits_added_then_changed_events() {
+        let (sender, mut receiver) = mpsc::channel(2);
+        let db = SqlRepository::new(MEMORY_DB_URL, Some(sender))
+            .await
+            .unwrap();
+        let original = sample_book(401, "Fantasy", "Earthsea.epub", "Earthsea");
+
+        db.save_book(&original).await.unwrap();
+
+        let added = receiver.try_recv().unwrap();
+        let LocalMessage::Book(added) = added else {
+            panic!("expected a book event");
+        };
+        assert_eq!(added.event_type, BookEventType::BookEventAdded);
+        assert_eq!(added.checksum, original.checksum.to_string());
+        assert_eq!(added.book.unwrap().title, original.title);
+
+        let replacement = sample_book(
+            402,
+            &original.collection,
+            &original.file_name,
+            "A Wizard of Earthsea",
+        );
+        db.save_book(&replacement).await.unwrap();
+
+        let changed = receiver.try_recv().unwrap();
+        let LocalMessage::Book(changed) = changed else {
+            panic!("expected a book event");
+        };
+        assert_eq!(changed.event_type, BookEventType::BookEventChanged);
+        assert_eq!(changed.checksum, replacement.checksum.to_string());
+        assert_eq!(changed.book.unwrap().title, replacement.title);
+    }
+
+    #[tokio::test]
+    async fn list_books_filters_collection_and_orders_by_title_then_file() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+        for book in [
+            sample_book(501, "Essays", "Zulu.epub", "Collected Essays"),
+            sample_book(502, "Essays", "Alpha.epub", "Collected Essays"),
+            sample_book(503, "Essays", "Beginning.epub", "A Beginning"),
+            sample_book(504, "Other", "Ignored.epub", "Ignored"),
+        ] {
+            db.save_book(&book).await.unwrap();
+        }
+
+        let books = db.list_books("Essays").await.unwrap();
+        let files = books
+            .into_iter()
+            .map(|book| book.file_name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            files,
+            vec!["Beginning.epub", "Alpha.epub", "Zulu.epub"]
+        );
+    }
+
+    #[tokio::test]
+    async fn list_book_collections_returns_sorted_nested_collection_names() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+        for (checksum, collection) in [
+            (601, "Fantasy"),
+            (602, "Fiction/Fantasy"),
+            (603, "Fiction/Classics"),
+            (604, "Fiction/Fantasy/Epic"),
+            (605, "Nonfiction/Essay"),
+            (606, ""),
+        ] {
+            let book = sample_book(
+                checksum,
+                collection,
+                &format!("{checksum}.epub"),
+                "Title",
+            );
+            db.save_book(&book).await.unwrap();
+        }
+
+        assert_eq!(
+            db.list_book_collections("").await.unwrap(),
+            vec!["Fantasy", "Fiction", "Nonfiction"]
+        );
+        assert_eq!(
+            db.list_book_collections("Fiction").await.unwrap(),
+            vec!["Classics", "Fantasy"]
+        );
+        assert_eq!(
+            db.list_book_collections("Fiction/Fantasy")
+                .await
+                .unwrap(),
+            vec!["Epic"]
+        );
+    }
+
+    #[tokio::test]
+    async fn list_all_books_orders_by_collection_title_and_file() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+        for book in [
+            sample_book(701, "B", "Zulu.epub", "Same"),
+            sample_book(702, "A", "Zulu.epub", "Same"),
+            sample_book(703, "A", "Alpha.epub", "Same"),
+            sample_book(704, "A", "Last.epub", "Zed"),
+            sample_book(705, "A", "First.epub", "Able"),
+        ] {
+            db.save_book(&book).await.unwrap();
+        }
+
+        let ordered = db
+            .list_all_books()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|book| (book.collection, book.file_name))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ordered,
+            vec![
+                ("A".to_string(), "First.epub".to_string()),
+                ("A".to_string(), "Alpha.epub".to_string()),
+                ("A".to_string(), "Zulu.epub".to_string()),
+                ("A".to_string(), "Last.epub".to_string()),
+                ("B".to_string(), "Zulu.epub".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_book_removes_row_and_emits_only_for_deleted_rows() {
+        let (sender, mut receiver) = mpsc::channel(3);
+        let db = SqlRepository::new(MEMORY_DB_URL, Some(sender))
+            .await
+            .unwrap();
+        let book = sample_book(801, "Classics", "Dune.epub", "Dune");
+        db.save_book(&book).await.unwrap();
+        receiver.try_recv().unwrap();
+
+        assert_eq!(db.delete_book(book.checksum).await.unwrap(), 1);
+        assert!(matches!(
+            db.retrieve_book(book.checksum).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+        let deleted = receiver.try_recv().unwrap();
+        let LocalMessage::Book(deleted) = deleted else {
+            panic!("expected a book event");
+        };
+        assert_eq!(deleted.event_type, BookEventType::BookEventDeleted);
+        assert_eq!(deleted.checksum, book.checksum.to_string());
+        assert!(deleted.book.is_none());
+
+        assert_eq!(db.delete_book(book.checksum).await.unwrap(), 0);
+        assert!(receiver.try_recv().is_err());
+    }
 
     #[tokio::test]
     async fn test_save_video_details() {

--- a/src/adaptors/repository.rs
+++ b/src/adaptors/repository.rs
@@ -135,19 +135,32 @@ impl SqlRepository {
 impl Databaser for SqlRepository {
     async fn save_book(&self, details: &BookDetails) -> Result<i64, sqlx::Error> {
         let mut tx = self.pool.begin().await?;
-        let is_update = sqlx::query(
-            r#"
-            SELECT 1
-            FROM books
-            WHERE checksum = ? OR (collection = ? AND file_name = ?)
-            "#,
+        let checksum_row = sqlx::query_scalar::<_, i64>(
+            "SELECT checksum FROM books WHERE checksum = ?",
         )
         .bind(details.checksum)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let path_row = sqlx::query_scalar::<_, i64>(
+            "SELECT checksum FROM books WHERE collection = ? AND file_name = ?",
+        )
         .bind(&details.collection)
         .bind(&details.file_name)
         .fetch_optional(&mut *tx)
-        .await?
-        .is_some();
+        .await?;
+        let is_update = checksum_row.is_some() || path_row.is_some();
+
+        if checksum_row.is_some() {
+            if let Some(path_checksum) = path_row {
+                if path_checksum != details.checksum {
+                    sqlx::query("DELETE FROM books WHERE checksum = ?")
+                        .bind(path_checksum)
+                        .execute(&mut *tx)
+                        .await?;
+                }
+            }
+        }
+
         let authors = serde_json::to_string(&details.authors).unwrap_or_default();
         let metadata = serde_json::to_string(&details.metadata).unwrap_or_default();
         let format = match details.format {
@@ -928,6 +941,74 @@ mod tests {
         assert_eq!(retrieved.collection, replacement.collection);
         assert_eq!(retrieved.file_name, replacement.file_name);
         assert_eq!(retrieved.title, replacement.title);
+    }
+
+    #[tokio::test]
+    async fn save_book_reconciles_different_checksum_and_path_rows() {
+        let (sender, mut receiver) = mpsc::channel(3);
+        let db = SqlRepository::new(MEMORY_DB_URL, Some(sender))
+            .await
+            .unwrap();
+        let checksum_book = sample_book(
+            351,
+            "Original",
+            "Durable Identity.epub",
+            "Original Checksum Book",
+        );
+        let stale_path_book = sample_book(
+            352,
+            "Incoming",
+            "Destination.epub",
+            "Stale Path Book",
+        );
+        db.save_book(&checksum_book).await.unwrap();
+        db.save_book(&stale_path_book).await.unwrap();
+        receiver.try_recv().unwrap();
+        receiver.try_recv().unwrap();
+        sqlx::query(
+            r#"
+            UPDATE books
+            SET created_on = '2020-01-01 00:00:00',
+                updated_on = '2020-01-02 00:00:00'
+            WHERE checksum = ?
+            "#,
+        )
+        .bind(checksum_book.checksum)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        let checksum_row_before = db.retrieve_book(checksum_book.checksum).await.unwrap();
+        let mut incoming = sample_book(
+            checksum_book.checksum,
+            &stale_path_book.collection,
+            &stale_path_book.file_name,
+            "Reconciled Book",
+        );
+        incoming.authors = vec!["Incoming Author".to_string()];
+        incoming.description = Some("Incoming metadata wins".to_string());
+
+        assert_eq!(db.save_book(&incoming).await.unwrap(), incoming.checksum);
+
+        let books = db.list_all_books().await.unwrap();
+        assert_eq!(books.len(), 1);
+        let reconciled = &books[0];
+        assert_eq!(reconciled.checksum, incoming.checksum);
+        assert_eq!(reconciled.collection, incoming.collection);
+        assert_eq!(reconciled.file_name, incoming.file_name);
+        assert_eq!(reconciled.title, incoming.title);
+        assert_eq!(reconciled.authors, incoming.authors);
+        assert_eq!(reconciled.description, incoming.description);
+        assert_eq!(reconciled.created_on, checksum_row_before.created_on);
+        assert!(reconciled.updated_on > checksum_row_before.updated_on);
+
+        let changed = receiver.try_recv().unwrap();
+        let LocalMessage::Book(changed) = changed else {
+            panic!("expected a book event");
+        };
+        assert_eq!(changed.event_type, BookEventType::BookEventChanged);
+        assert_eq!(changed.checksum, incoming.checksum.to_string());
+        assert_eq!(changed.book.unwrap().title, incoming.title);
+        assert!(receiver.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/src/adaptors/repository.rs
+++ b/src/adaptors/repository.rs
@@ -291,10 +291,11 @@ impl Databaser for SqlRepository {
                 r#"
                 SELECT DISTINCT collection
                 FROM books
-                WHERE collection LIKE ?
+                WHERE substr(collection, 1, length(?) + 1) = (? || '/')
                 "#,
             )
-            .bind(format!("{}%", parent_collection))
+            .bind(parent_collection)
+            .bind(parent_collection)
             .fetch_all(&self.pool)
             .await?
         };
@@ -899,6 +900,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn save_and_retrieve_book_round_trips_pdf_format() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+        let mut book = sample_book(151, "Documents", "Specification.pdf", "Specification");
+        book.format = BookFormat::Pdf;
+
+        db.save_book(&book).await.unwrap();
+        let retrieved = db.retrieve_book(book.checksum).await.unwrap();
+
+        assert_eq!(retrieved.format, BookFormat::Pdf);
+        assert_eq!(retrieved.file_name, book.file_name);
+        assert_eq!(retrieved.title, book.title);
+    }
+
+    #[tokio::test]
     async fn save_book_updates_on_collection_and_file_conflict() {
         let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
         let original = sample_book(201, "Fantasy", "Earthsea.epub", "A Wizard of Earthsea");
@@ -1103,6 +1118,35 @@ mod tests {
                 .await
                 .unwrap(),
             vec!["Epic"]
+        );
+    }
+
+    #[tokio::test]
+    async fn list_book_collections_excludes_sibling_prefixes_and_like_wildcards() {
+        let db = SqlRepository::new(MEMORY_DB_URL, None).await.unwrap();
+        for (checksum, collection) in [
+            (651, "Fiction/Fantasy"),
+            (652, "Fictional/Essays"),
+            (653, "Shelf%/ExactPercent"),
+            (654, "ShelfX/WrongPercent"),
+            (655, "Under_/ExactUnderscore"),
+            (656, "UnderX/WrongUnderscore"),
+        ] {
+            let book = sample_book(checksum, collection, &format!("{checksum}.epub"), "Title");
+            db.save_book(&book).await.unwrap();
+        }
+
+        assert_eq!(
+            db.list_book_collections("Fiction").await.unwrap(),
+            vec!["Fantasy"]
+        );
+        assert_eq!(
+            db.list_book_collections("Shelf%").await.unwrap(),
+            vec!["ExactPercent"]
+        );
+        assert_eq!(
+            db.list_book_collections("Under_").await.unwrap(),
+            vec!["ExactUnderscore"]
         );
     }
 

--- a/src/domain/traits.rs
+++ b/src/domain/traits.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::messages::{MediaItem, RemoteMessage, TaskState};
-use super::models::{CollectionItem, DownloadableItem, SearchResults, VideoDetails};
+use super::models::{BookDetails, CollectionItem, DownloadableItem, SearchResults, VideoDetails};
 use anyhow;
 use async_trait::async_trait;
 use axum::http::StatusCode;
@@ -165,6 +165,15 @@ pub type Spawner = Arc<dyn ProcessSpawner>;
 
 #[async_trait]
 pub trait Databaser: Sync + Send {
+    async fn save_book(&self, details: &BookDetails) -> Result<i64, sqlx::Error>;
+    async fn list_book_collections(
+        &self,
+        collection: &str,
+    ) -> Result<Vec<String>, sqlx::Error>;
+    async fn list_books(&self, collection: &str) -> Result<Vec<BookDetails>, sqlx::Error>;
+    async fn list_all_books(&self) -> Result<Vec<BookDetails>, sqlx::Error>;
+    async fn retrieve_book(&self, checksum: i64) -> Result<BookDetails, sqlx::Error>;
+    async fn delete_book(&self, checksum: i64) -> Result<u64, sqlx::Error>;
     async fn save_video(&self, details: &VideoDetails) -> Result<i64, sqlx::Error>;
     async fn list_collection(&self, collection: &str)  -> Result<Vec<String>, sqlx::Error>;
     async fn list_videos(&self, collection: &str)  -> Result<Vec<VideoDetails>, sqlx::Error>;


### PR DESCRIPTION
## Summary

- add the `books` SQLite migration and required indexes
- add book CRUD, listing, nested collection, and stable ordering methods to the repository contract and `SqlRepository`
- persist authors and extractor metadata as structured JSON and restore them into domain types
- reconcile checksum/path identity conflicts transactionally and emit add/change/delete book events after commit
- cover EPUB and PDF round trips, both upsert keys, dual-key reconciliation, exact collection boundaries, listings, deletion, and events with real SQLite/Tokio tests

## Why

Task 4 establishes durable book persistence for the ebook-support design while keeping the existing video repository behavior unchanged.

## Impact

Later book-store, ingestion, scanner, REST, and Tauri tasks can rely on a stable book repository API and event contract. Collection queries now honor literal path boundaries, including names containing `%` or `_`.

## Verification

- `make test` — 88 unit tests passed, 4 ignored; 7 integration tests passed; 0 failures
- `make build` — webserver build passed
- `git diff --check origin/spec/ebook-support..HEAD`
- independent task-scoped and whole-branch reviews found no Critical or Important issues

The suite still reports the pre-existing `DEFAULT_MIGRATIONS_DIR` dead-code warning. Strict malformed-row JSON/format decoding is recorded as non-blocking follow-up hardening.

Closes #39.
Related to #38 and prerequisite PR #50.