### PR TITLE
Add BookStore service for ebook support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ async-trait = "0.1.64"
 base64 = "0.22"
 axum = { version = "0.8.1", features = ["ws", "macros", "tokio"] }
 bytesize = {version = "1.1.0", features = ["serde"] }
+cap-fs-ext = "4.0.2"
+cap-std = "4.0.2"
 chrono = {version = "0.4.25", features= ["serde"] }
 futures = "0.3" 
 html-escape = "0.2.13"

--- a/src/adaptors/object_store.rs
+++ b/src/adaptors/object_store.rs
@@ -1,31 +1,47 @@
 use crate::domain::models::VideoDetails;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use cap_fs_ext::{
+    FollowSymlinks, MetadataExt, OpenOptionsFollowExt, OpenOptionsMaybeDirExt,
+};
+use cap_std::{
+    ambient_authority,
+    fs::{Dir, OpenOptions},
+};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::collections::VecDeque;
+use std::ffi::OsString;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 use tokio::{fs, io::AsyncWriteExt};
 
 use crate::domain::traits::{FileStore, Filer, StoreObject};
 
+#[derive(Clone)]
 pub struct FileSystemStore {
     root: String,
+    root_dir: Arc<OnceLock<Dir>>,
 }
 
 impl FileSystemStore {
     pub fn new(root: &str) -> Self {
-        Self {
+        let store = Self {
             root: root.to_string(),
-        }
+            root_dir: Arc::new(OnceLock::new()),
+        };
+        let _ = store.open_root();
+        store
     }
 
     fn get_real_path(&self, path: &str) -> Result<PathBuf, anyhow::Error> {
-        let first_char = path.chars().nth(0);
-        let resolved = if first_char == Some('/') || path.starts_with(&self.root) {
-            PathBuf::from(path)
+        let requested = Path::new(path);
+        let root = Path::new(&self.root);
+        let resolved = if requested.is_absolute() || requested.starts_with(root) {
+            requested.to_path_buf()
         } else {
-            Path::new(&self.root).join(path)
+            root.join(requested)
         };
 
         // Normalize path components to prevent traversal (e.g. "../../etc/passwd")
@@ -54,6 +70,236 @@ impl FileSystemStore {
 
         Ok(normalized)
     }
+
+    fn open_root(&self) -> Result<&Dir> {
+        if self.root_dir.get().is_none() {
+            let root_path = self.normalized_root()?;
+            let anchor = root_path.ancestors().last().ok_or_else(|| {
+                anyhow!("filesystem root has no volume anchor: {}", root_path.display())
+            })?;
+            let relative_root = root_path.strip_prefix(anchor)?;
+            let mut pending = Vec::new();
+            append_relative_components(&mut pending, relative_root)?;
+            let mut pending = VecDeque::from(pending);
+            let mut resolved = Vec::new();
+            let mut symlink_hops = 0;
+            let mut root = Dir::open_ambient_dir(anchor, ambient_authority())?;
+            while let Some(component) = pending.pop_front() {
+                let component = Path::new(&component);
+                match root.create_dir(component) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                    Err(error) => return Err(error.into()),
+                }
+                let expected = root.symlink_metadata(component)?;
+                if expected.file_type().is_symlink() {
+                    let target = root.read_link(component)?;
+                    let observed = root.symlink_metadata(component)?;
+                    if !observed.file_type().is_symlink()
+                        || observed.dev() != expected.dev()
+                        || observed.ino() != expected.ino()
+                    {
+                        return Err(anyhow!(
+                            "filesystem root symlink changed while it was read: {}",
+                            component.display()
+                        ));
+                    }
+                    symlink_hops += 1;
+                    if symlink_hops > 40 {
+                        return Err(anyhow!(
+                            "too many symlinks while opening filesystem root: {}",
+                            root_path.display()
+                        ));
+                    }
+
+                    let mut redirected = if target.is_absolute() {
+                        let relative_target = target.strip_prefix(anchor).map_err(|_| {
+                            anyhow!(
+                                "filesystem root symlink changes volume: {}",
+                                target.display()
+                            )
+                        })?;
+                        let mut components = Vec::new();
+                        append_relative_components(&mut components, relative_target)?;
+                        components
+                    } else {
+                        let mut components = resolved.clone();
+                        append_relative_components(&mut components, &target)?;
+                        components
+                    };
+                    redirected.extend(pending);
+                    pending = VecDeque::from(redirected);
+                    resolved.clear();
+                    root = Dir::open_ambient_dir(anchor, ambient_authority())?;
+                    continue;
+                }
+                if !expected.is_dir() {
+                    return Err(anyhow!(
+                        "filesystem root component is not a directory: {}",
+                        component.display()
+                    ));
+                }
+                let mut options = OpenOptions::new();
+                options
+                    .read(true)
+                    .maybe_dir(true)
+                    .follow(FollowSymlinks::Yes);
+                let child = root.open_with(component, &options)?;
+                let opened = child.metadata()?;
+                if !opened.is_dir()
+                    || opened.dev() != expected.dev()
+                    || opened.ino() != expected.ino()
+                {
+                    return Err(anyhow!(
+                        "filesystem root component changed while it was opened: {}",
+                        component.display()
+                    ));
+                }
+                root = Dir::from_std_file(child.into_std());
+                resolved.push(component.as_os_str().to_os_string());
+            }
+            let _ = self.root_dir.set(root);
+        }
+        self.root_dir
+            .get()
+            .ok_or_else(|| anyhow!("failed to retain filesystem root capability"))
+    }
+
+    fn normalized_root(&self) -> Result<PathBuf> {
+        Ok(std::path::absolute(self.get_real_path("")?)?)
+    }
+
+    fn rooted_relative_path(&self, path: &Path) -> Result<PathBuf> {
+        let path = path.to_str().ok_or_else(|| {
+            anyhow!("filesystem path is not valid UTF-8: {}", path.display())
+        })?;
+        let resolved = std::path::absolute(self.get_real_path(path)?)?;
+        let root = self.normalized_root()?;
+        resolved
+            .strip_prefix(&root)
+            .map(Path::to_path_buf)
+            .map_err(|_| anyhow!("path escapes root directory: {}", resolved.display()))
+    }
+
+    fn source_path(&self, path: &str) -> Result<PathBuf> {
+        let direct = PathBuf::from(path);
+        match std::fs::symlink_metadata(&direct) {
+            Ok(_) => Ok(std::path::absolute(direct)?),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                Ok(std::path::absolute(self.get_real_path(path)?)?)
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+fn append_relative_components(components: &mut Vec<OsString>, path: &Path) -> Result<()> {
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if components.pop().is_none() {
+                    return Err(anyhow!(
+                        "filesystem root symlink escapes its volume: {}",
+                        path.display()
+                    ));
+                }
+            }
+            Component::Normal(component) => components.push(component.to_os_string()),
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(anyhow!(
+                    "expected a relative filesystem root component: {}",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_cross_device(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::CrossesDevices
+}
+
+fn unique_staging_name(prefix: &str) -> String {
+    format!(".{prefix}-{:032x}", rand::random::<u128>())
+}
+
+fn ensure_cap_regular_file(dir: &Dir, path: &Path, description: &str) -> Result<()> {
+    let metadata = dir.symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(anyhow!(
+            "{description} must be a regular file and not a symlink: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn restore_staged_file(dir: &Dir, staged: &Path, original: &Path) -> Result<()> {
+    ensure_cap_regular_file(dir, staged, "staged file")?;
+    dir.hard_link(staged, dir, original).map_err(|error| {
+        anyhow!(
+            "failed to restore {} to {} without replacing an existing file: {error}",
+            staged.display(),
+            original.display()
+        )
+    })?;
+    if let Err(error) = dir.remove_file(staged) {
+        tracing::warn!(
+            "Restored staged file to {} but could not remove {}: {}",
+            original.display(),
+            staged.display(),
+            error
+        );
+    }
+    Ok(())
+}
+
+fn copy_staged_file(
+    source_dir: &Dir,
+    staged_source: &Path,
+    destination_dir: &Dir,
+    destination: &Path,
+) -> Result<()> {
+    let mut source_options = OpenOptions::new();
+    source_options.read(true).follow(FollowSymlinks::No);
+    let mut source = source_dir.open_with(staged_source, &source_options)?;
+    let source_metadata = source.metadata()?;
+    if !source_metadata.is_file() {
+        return Err(anyhow!("source must be a regular file"));
+    }
+
+    let destination_parent = destination.parent().unwrap_or_else(|| Path::new(""));
+    let temporary = destination_parent.join(unique_staging_name("tvserver-copy"));
+    let mut destination_options = OpenOptions::new();
+    destination_options
+        .write(true)
+        .create_new(true)
+        .follow(FollowSymlinks::No);
+    let mut copied = destination_dir.open_with(&temporary, &destination_options)?;
+
+    let result = (|| -> Result<()> {
+        io::copy(&mut source, &mut copied)?;
+        destination_dir.set_permissions(&temporary, source_metadata.permissions())?;
+        copied.sync_all()?;
+        drop(copied);
+        drop(source);
+        destination_dir.rename(&temporary, destination_dir, destination)?;
+        if let Err(error) = source_dir.remove_file(staged_source) {
+            tracing::warn!(
+                "Published cross-device copy at {} but could not remove staged source {}: {}",
+                destination.display(),
+                staged_source.display(),
+                error
+            );
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = destination_dir.remove_file(&temporary);
+    }
+    result
 }
 
 pub struct FileStoreObject {
@@ -120,9 +366,14 @@ impl Filer for FileStoreObject {
 #[async_trait]
 impl FileStore for FileSystemStore {
     async fn create_folder(&self, path: &Path) -> Result<()> {
-        if !path.exists() {
-            fs::create_dir_all(&path).await?;
-        }
+        let store = self.clone();
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            let relative = store.rooted_relative_path(&path)?;
+            store.open_root()?.create_dir_all(relative)?;
+            Result::<()>::Ok(())
+        })
+        .await??;
         Ok(())
     }
 
@@ -169,22 +420,79 @@ impl FileStore for FileSystemStore {
     }
 
     async fn rename(&self, _old_path: &str, _new_path: &str) -> Result<()> {
-        let mut old_path = PathBuf::from(_old_path);
-        if !old_path.exists() {
-            old_path = self.get_real_path(_old_path)?;
-        }
-        let new_path = self.get_real_path(_new_path)?;
+        let store = self.clone();
+        let old_path = _old_path.to_string();
+        let new_path = PathBuf::from(_new_path);
+        tokio::task::spawn_blocking(move || {
+            let old_path = store.source_path(&old_path)?;
+            let destination = store.rooted_relative_path(&new_path)?;
+            let destination_dir = store.open_root()?;
+            let root_path = store.normalized_root()?;
+            let internal_source = old_path.strip_prefix(&root_path).ok().map(Path::to_path_buf);
+            let ambient_source;
+            let (source_dir, source_path) = if let Some(relative) = internal_source {
+                (destination_dir, relative)
+            } else {
+                let old_parent = old_path.parent().ok_or_else(|| {
+                    anyhow!("source path has no parent: {}", old_path.display())
+                })?;
+                let old_name = old_path.file_name().ok_or_else(|| {
+                    anyhow!("source path has no file name: {}", old_path.display())
+                })?;
+                ambient_source = Dir::open_ambient_dir(old_parent, ambient_authority())?;
+                (&ambient_source, PathBuf::from(old_name))
+            };
+            ensure_cap_regular_file(source_dir, &source_path, "source file")?;
 
-        match fs::rename(&old_path, &new_path).await {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == std::io::ErrorKind::Other
-                    || e.raw_os_error() == Some(18) /* EXDEV */ => {
-                fs::copy(&old_path, &new_path).await?;
-                fs::remove_file(&old_path).await?;
-                Ok(())
+            let staged_source = PathBuf::from(unique_staging_name("tvserver-move"));
+            source_dir.rename(&source_path, source_dir, &staged_source)?;
+
+            let move_result = (|| -> Result<()> {
+                ensure_cap_regular_file(source_dir, &staged_source, "source file")?;
+                match source_dir.rename(&staged_source, destination_dir, &destination) {
+                    Ok(()) => ensure_cap_regular_file(
+                        destination_dir,
+                        &destination,
+                        "destination file",
+                    ),
+                    Err(error) if is_cross_device(&error) => copy_staged_file(
+                        source_dir,
+                        &staged_source,
+                        destination_dir,
+                        &destination,
+                    ),
+                    Err(error) => Err(error.into()),
+                }
+            })();
+
+            if let Err(error) = move_result {
+                if source_dir.symlink_metadata(&staged_source).is_ok() {
+                    restore_staged_file(source_dir, &staged_source, &source_path).map_err(
+                        |restore_error| {
+                            anyhow!(
+                                "{error}; additionally failed to restore source {}: {restore_error}",
+                                old_path.display()
+                            )
+                        },
+                    )?;
+                }
+                return Err(error);
             }
-            Err(e) => Err(anyhow!(e)),
-        }
+            Ok(())
+        })
+        .await?
+    }
+
+    async fn restore(&self, staged_path: &str, original_path: &str) -> Result<()> {
+        let store = self.clone();
+        let staged_path = PathBuf::from(staged_path);
+        let original_path = PathBuf::from(original_path);
+        tokio::task::spawn_blocking(move || {
+            let staged_path = store.rooted_relative_path(&staged_path)?;
+            let original_path = store.rooted_relative_path(&original_path)?;
+            restore_staged_file(store.open_root()?, &staged_path, &original_path)
+        })
+        .await?
     }
 
     async fn get(&self, path: &str) -> anyhow::Result<StoreObject> {
@@ -193,15 +501,32 @@ impl FileStore for FileSystemStore {
     }
 
     async fn delete(&self, path: &str) -> Result<()> {
-        let file_path = self.get_real_path(path)?;
-        if !file_path.exists() {
-            return Ok(());
-        }
-
-        match fs::remove_file(file_path).await {
-            Ok(()) => Ok(()),
-            Err(e) => Err(anyhow!(e)),
-        }
+        let store = self.clone();
+        let path = PathBuf::from(path);
+        tokio::task::spawn_blocking(move || {
+            let relative = store.rooted_relative_path(&path)?;
+            let root = store.open_root()?;
+            match root.symlink_metadata(&relative) {
+                Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => Err(
+                    anyhow!("file must be a regular file and not a symlink: {}", path.display()),
+                ),
+                Ok(_) => {
+                    let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+                    let staged = parent.join(unique_staging_name("tvserver-delete"));
+                    root.rename(&relative, root, &staged)?;
+                    if let Err(error) = ensure_cap_regular_file(root, &staged, "staged file") {
+                        return Err(anyhow!(
+                            "{error}; unsafe replacement was quarantined at {}",
+                            staged.display()
+                        ));
+                    }
+                    Ok(root.remove_file(staged)?)
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error.into()),
+            }
+        })
+        .await?
     }
 
     async fn remove_empty_dir(&self, path: &Path) -> Result<()> {
@@ -331,6 +656,336 @@ mod tests {
         let store: &dyn FileStore = &FileSystemStore::new(TEST_DIR);
         let result = store.delete("../../etc/passwd").await;
         assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn delete_rejects_dangling_symlink_without_removing_it() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-delete-link-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        fs::create_dir_all(&root).await.unwrap();
+        let link = root.join("Dune.epub");
+        symlink(base.join("missing.epub"), &link).unwrap();
+        let store = FileSystemStore::new(root.to_str().unwrap());
+
+        let result = store.delete(link.to_str().unwrap()).await;
+        let link_exists = link.symlink_metadata().is_ok();
+        let _ = fs::remove_dir_all(&base).await;
+
+        assert!(result.is_err());
+        assert!(link_exists);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rename_does_not_follow_destination_parent_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-rename-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        let outside = base.join("outside");
+        fs::create_dir_all(&root).await.unwrap();
+        fs::create_dir(&outside).await.unwrap();
+        symlink(&outside, root.join("Fiction")).unwrap();
+        let source = base.join("Dune.epub");
+        fs::write(&source, b"book").await.unwrap();
+        let destination = root.join("Fiction/Dune.epub");
+        let store = FileSystemStore::new(root.to_str().unwrap());
+
+        let result = store
+            .rename(source.to_str().unwrap(), destination.to_str().unwrap())
+            .await;
+        let source_exists = source.exists();
+        let outside_exists = outside.join("Dune.epub").exists();
+        let _ = fs::remove_dir_all(&base).await;
+
+        assert!(result.is_err());
+        assert!(source_exists);
+        assert!(!outside_exists);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rename_stays_anchored_when_store_root_is_replaced() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-root-swap-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        let original_root = base.join("original-root");
+        let outside = base.join("outside");
+        fs::create_dir_all(&root).await.unwrap();
+        fs::create_dir(&outside).await.unwrap();
+        let store = FileSystemStore::new(root.to_str().unwrap());
+        fs::rename(&root, &original_root).await.unwrap();
+        symlink(&outside, &root).unwrap();
+        let source = base.join("Dune.epub");
+        fs::write(&source, b"book").await.unwrap();
+        let destination = root.join("Dune.epub");
+
+        let result = store
+            .rename(source.to_str().unwrap(), destination.to_str().unwrap())
+            .await;
+        let outside_exists = outside.join("Dune.epub").exists();
+        let preserved = result.is_err() && source.exists()
+            || result.is_ok() && original_root.join("Dune.epub").exists();
+        let _ = fs::remove_dir_all(&base).await;
+
+        assert!(!outside_exists);
+        assert!(preserved);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rename_uses_root_capability_for_internal_source() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-source-swap-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        let original_collection = base.join("original-fiction");
+        let outside = base.join("outside");
+        fs::create_dir_all(root.join("Fiction")).await.unwrap();
+        fs::create_dir(&outside).await.unwrap();
+        fs::write(root.join("Fiction/Dune.epub"), b"inside")
+            .await
+            .unwrap();
+        fs::write(outside.join("Dune.epub"), b"outside")
+            .await
+            .unwrap();
+        let store = FileSystemStore::new(root.to_str().unwrap());
+        fs::rename(root.join("Fiction"), &original_collection)
+            .await
+            .unwrap();
+        symlink(&outside, root.join("Fiction")).unwrap();
+        let source = root.join("Fiction/Dune.epub");
+        let destination = root.join("quarantine.epub");
+
+        let result = store
+            .rename(source.to_str().unwrap(), destination.to_str().unwrap())
+            .await;
+        let outside_contents = fs::read(outside.join("Dune.epub")).await.ok();
+        let quarantined_contents = fs::read(&destination).await.ok();
+        let original_contents = fs::read(original_collection.join("Dune.epub")).await.ok();
+        let _ = fs::remove_dir_all(&base).await;
+
+        assert_eq!(outside_contents.as_deref(), Some(b"outside".as_slice()));
+        assert!(
+            result.is_err() && original_contents.as_deref() == Some(b"inside".as_slice())
+                || result.is_ok()
+                    && quarantined_contents.as_deref() == Some(b"inside".as_slice())
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn create_folder_does_not_follow_parent_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-create-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        let outside = base.join("outside");
+        fs::create_dir_all(&root).await.unwrap();
+        fs::create_dir(&outside).await.unwrap();
+        symlink(&outside, root.join("Fiction")).unwrap();
+        let destination = root.join("Fiction/Classics");
+        let store = FileSystemStore::new(root.to_str().unwrap());
+
+        let result = store.create_folder(&destination).await;
+        let outside_exists = outside.join("Classics").exists();
+        let _ = fs::remove_dir_all(&base).await;
+
+        assert!(result.is_err());
+        assert!(!outside_exists);
+    }
+
+    #[tokio::test]
+    async fn create_folder_creates_missing_store_root() {
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-create-root-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        let destination = root.join("Fiction");
+        let store = FileSystemStore::new(root.to_str().unwrap());
+
+        let result = store.create_folder(&destination).await;
+        let destination_exists = destination.is_dir();
+        let _ = fs::remove_dir_all(&base).await;
+
+        assert!(result.is_ok(), "{result:?}");
+        assert!(destination_exists);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn create_folder_rejects_symlink_installed_at_missing_root() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-missing-root-swap-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        let outside = base.join("outside");
+        fs::create_dir_all(&outside).await.unwrap();
+        let store = FileSystemStore::new(root.to_str().unwrap());
+        if root.exists() {
+            fs::remove_dir(&root).await.unwrap();
+        }
+        symlink(&outside, &root).unwrap();
+        let destination = root.join("Fiction");
+
+        let result = store.create_folder(&destination).await;
+        let outside_exists = outside.join("Fiction").exists();
+        let _ = fs::remove_dir_all(&base).await;
+
+        assert!(result.is_err());
+        assert!(!outside_exists);
+    }
+
+    #[tokio::test]
+    async fn create_folder_accepts_normalized_store_root() {
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-normalized-root-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        fs::create_dir_all(base.join("parent")).await.unwrap();
+        let configured_root = base.join("parent/../root");
+        let destination = base.join("root/Fiction");
+        let store = FileSystemStore::new(configured_root.to_str().unwrap());
+
+        let result = store.create_folder(&destination).await;
+        let destination_exists = destination.is_dir();
+        let _ = fs::remove_dir_all(&base).await;
+
+        assert!(result.is_ok(), "{result:?}");
+        assert!(destination_exists);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cross_device_copy_replaces_destination_symlink_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-copy-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let source_root = base.join("source");
+        let destination_root = base.join("destination");
+        std::fs::create_dir_all(&source_root).unwrap();
+        std::fs::create_dir(&destination_root).unwrap();
+        std::fs::write(source_root.join("staged.epub"), b"book").unwrap();
+        let outside = base.join("outside.epub");
+        std::fs::write(&outside, b"outside").unwrap();
+        symlink(&outside, destination_root.join("Dune.epub")).unwrap();
+        let source_dir = Dir::open_ambient_dir(&source_root, ambient_authority()).unwrap();
+        let destination_dir =
+            Dir::open_ambient_dir(&destination_root, ambient_authority()).unwrap();
+
+        let result = copy_staged_file(
+            &source_dir,
+            Path::new("staged.epub"),
+            &destination_dir,
+            Path::new("Dune.epub"),
+        );
+        let outside_contents = std::fs::read(&outside).unwrap();
+        let destination_contents = std::fs::read(destination_root.join("Dune.epub")).unwrap();
+        let source_exists = source_root.join("staged.epub").exists();
+        let _ = std::fs::remove_dir_all(&base);
+
+        assert!(result.is_ok());
+        assert_eq!(outside_contents, b"outside");
+        assert_eq!(destination_contents, b"book");
+        assert!(!source_exists);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cross_device_copy_is_committed_after_destination_publication() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-copy-commit-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let source_root = base.join("source");
+        let destination_root = base.join("destination");
+        std::fs::create_dir_all(&source_root).unwrap();
+        std::fs::create_dir(&destination_root).unwrap();
+        std::fs::write(source_root.join("staged.epub"), b"book").unwrap();
+        let source_dir = Dir::open_ambient_dir(&source_root, ambient_authority()).unwrap();
+        let destination_dir =
+            Dir::open_ambient_dir(&destination_root, ambient_authority()).unwrap();
+        std::fs::set_permissions(&source_root, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = copy_staged_file(
+            &source_dir,
+            Path::new("staged.epub"),
+            &destination_dir,
+            Path::new("Dune.epub"),
+        );
+        std::fs::set_permissions(&source_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let destination_contents = std::fs::read(destination_root.join("Dune.epub")).unwrap();
+        let source_exists = source_root.join("staged.epub").exists();
+        let _ = std::fs::remove_dir_all(&base);
+
+        assert!(result.is_ok());
+        assert_eq!(destination_contents, b"book");
+        assert!(source_exists);
+    }
+
+    #[tokio::test]
+    async fn restore_does_not_overwrite_replacement() {
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-rooted-restore-collision-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("staged.epub"), b"original").unwrap();
+        std::fs::write(base.join("Dune.epub"), b"replacement").unwrap();
+        let store = FileSystemStore::new(base.to_str().unwrap());
+
+        let result = store
+            .restore(
+                base.join("staged.epub").to_str().unwrap(),
+                base.join("Dune.epub").to_str().unwrap(),
+            )
+            .await;
+        let original = std::fs::read(base.join("staged.epub")).unwrap();
+        let replacement = std::fs::read(base.join("Dune.epub")).unwrap();
+        let _ = std::fs::remove_dir_all(&base);
+
+        assert!(result.is_err());
+        assert_eq!(original, b"original");
+        assert_eq!(replacement, b"replacement");
     }
 
     // TODO,rename ensure_path_exists -> ensure_directory_exists and test when there is a file

--- a/src/domain/traits.rs
+++ b/src/domain/traits.rs
@@ -124,6 +124,7 @@ pub trait FileStore: Sync + Send {
     async fn list_folder(&self, path: &str) -> anyhow::Result<(Vec<String>, Vec<String>)>;
     async fn ensure_path_exists(&self, path: &str) -> anyhow::Result<()>;
     async fn rename(&self, old_path: &str, new_path: &str) -> anyhow::Result<()>;
+    async fn restore(&self, staged_path: &str, original_path: &str) -> anyhow::Result<()>;
     async fn get(&self, path: &str) -> anyhow::Result<StoreObject>;
     async fn delete(&self, path: &str) -> anyhow::Result<()>;
     async fn remove_empty_dir(&self, path: &Path) -> anyhow::Result<()>;

--- a/src/entrypoints/context.rs
+++ b/src/entrypoints/context.rs
@@ -1,16 +1,25 @@
 use std::sync::Arc;
 
-use crate::adaptors::{FileSystemStore, HTTPClient, SqlRepository, TelegramBot, TokioProcessSpawner, TorrentFetcher, YoutubeFetcher};
-use crate::domain::config::{get_database_url, get_google_key, get_movie_dir, get_telegram_token, get_telegram_chat_id};
-use crate::domain::messagebus::{LocalMessageExchange, LocalMessageExchangeError, MessageExchange, MessageFilter};
+use crate::adaptors::{
+    FileSystemStore, HTTPClient, SqlRepository, TelegramBot, TokioProcessSpawner, TorrentFetcher,
+    YoutubeFetcher,
+};
+use crate::domain::config::{
+    get_book_dir, get_book_thumbnail_dir, get_database_url, get_google_key, get_movie_dir,
+    get_telegram_chat_id, get_telegram_token,
+};
+use crate::domain::messagebus::{
+    LocalMessageExchange, LocalMessageExchangeError, MessageExchange, MessageFilter,
+};
 use crate::domain::messages::{LocalMessageReceiver, LocalMessageSender};
 use crate::domain::services::MediaCheck;
 use crate::domain::traits::FileStorer;
+use crate::domain::traits::{Checker, ProcessSpawner, Repository, Storer};
 use crate::domain::SearchEngineType;
 use crate::services::{
-    MediaStore, PirateClient, SearchEngine, SearchService, TaskManager, YoutubeClient, SharingService
+    BookStore, MediaStore, PirateClient, SearchEngine, SearchService, SharingService, TaskManager,
+    YoutubeClient,
 };
-use crate::domain::traits::{Checker, ProcessSpawner, Repository, Storer};
 
 #[derive(Clone)]
 pub struct Context {
@@ -21,8 +30,10 @@ pub struct Context {
     task_manager: Arc<TaskManager>,
     repository: Repository,
     local_message_exchange: LocalMessageExchange,
+    book_store: Arc<BookStore>,
+    book_file_storer: FileStorer,
     sharing: Option<Arc<SharingService>>,
-}   
+}
 
 impl Context {
     pub fn new(
@@ -33,6 +44,8 @@ impl Context {
         repository: Repository,
         checker: Checker,
         local_message_exchange: LocalMessageExchange,
+        book_store: Arc<BookStore>,
+        book_file_storer: FileStorer,
         sharing: Option<Arc<SharingService>>,
     ) -> Context {
         Context {
@@ -43,6 +56,8 @@ impl Context {
             task_manager,
             repository,
             local_message_exchange,
+            book_store,
+            book_file_storer,
             sharing,
         }
     }
@@ -67,8 +82,13 @@ impl Context {
         self.local_message_exchange.new_sender()
     }
 
-    pub async fn listen_for_messages(&self, filter: MessageFilter) -> Result<LocalMessageReceiver, LocalMessageExchangeError> {
-        self.local_message_exchange.listen_for_messages(filter).await
+    pub async fn listen_for_messages(
+        &self,
+        filter: MessageFilter,
+    ) -> Result<LocalMessageReceiver, LocalMessageExchangeError> {
+        self.local_message_exchange
+            .listen_for_messages(filter)
+            .await
     }
 
     pub fn get_checker(&self) -> Checker {
@@ -94,11 +114,19 @@ impl Context {
     pub fn get_sharing(&self) -> Option<Arc<SharingService>> {
         self.sharing.clone()
     }
+
+    pub fn get_book_store(&self) -> Arc<BookStore> {
+        self.book_store.clone()
+    }
+
+    pub fn get_book_file_storer(&self) -> FileStorer {
+        self.book_file_storer.clone()
+    }
 }
 
 pub async fn create_context() -> anyhow::Result<Context> {
     let local_message_exchange = LocalMessageExchange::new();
-    
+
     let spawner = Arc::new(TokioProcessSpawner::new());
 
     let web_fetcher = Arc::new(HTTPClient::new());
@@ -110,51 +138,62 @@ pub async fn create_context() -> anyhow::Result<Context> {
     let youtube_fetcher = Arc::new(YoutubeFetcher::new(spawner.clone()));
 
     let repository = Arc::new(
-        SqlRepository::new(&get_database_url(), Some(local_message_exchange.new_sender())).await?
+        SqlRepository::new(&get_database_url(), Some(local_message_exchange.new_sender())).await?,
     );
 
-    let torrent_search = Arc::new(
-        SearchEngine::new(
-            SearchEngineType::Torrent, 
-            Arc::new(PirateClient::new(web_fetcher.clone(), None)),
-            torrent_fetcher,
-        )
-    );
+    let torrent_search = Arc::new(SearchEngine::new(
+        SearchEngineType::Torrent,
+        Arc::new(PirateClient::new(web_fetcher.clone(), None)),
+        torrent_fetcher,
+    ));
 
-    let youtube_search = Arc::new(
-        SearchEngine::new(
-            SearchEngineType::YouTube, 
-            Arc::new(YoutubeClient::new(&get_google_key(), web_fetcher.clone())),
-            youtube_fetcher,
-        )
-    );
+    let youtube_search = Arc::new(SearchEngine::new(
+        SearchEngineType::YouTube,
+        Arc::new(YoutubeClient::new(&get_google_key(), web_fetcher.clone())),
+        youtube_fetcher,
+    ));
 
     let search_service = SearchService::new(
         task_manager.clone(),
         vec![torrent_search, youtube_search],
-        repository.clone()
+        repository.clone(),
     );
 
     let messenger = MessageExchange::new(
-        local_message_exchange.new_sender(), 
-        local_message_exchange.listen_for_messages( MessageFilter::All).await
-            .map_err(|e| anyhow::anyhow!("failed to listen for messages: {}", e))?
+        local_message_exchange.new_sender(),
+        local_message_exchange
+            .listen_for_messages(MessageFilter::All)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to listen for messages: {}", e))?,
     );
 
     let file_storer: FileStorer = Arc::new(FileSystemStore::new(&get_movie_dir()));
+    let book_dir = get_book_dir();
+    let book_thumbnail_dir = get_book_thumbnail_dir(&book_dir);
+    let book_file_storer: FileStorer = Arc::new(FileSystemStore::new(&book_dir));
+    let book_thumbnail_file_storer: FileStorer = Arc::new(FileSystemStore::new(
+        book_thumbnail_dir.to_str().unwrap_or_default(),
+    ));
+    let book_store = Arc::new(BookStore::new_with_roots(
+        book_file_storer.clone(),
+        book_thumbnail_file_storer,
+        repository.clone(),
+        &book_dir,
+        &book_thumbnail_dir,
+    ));
 
-    let checker = Arc::new(
-        MediaCheck::new(file_storer.clone(), 
-        repository.clone(), 
-        local_message_exchange.new_sender())
-    );
+    let checker = Arc::new(MediaCheck::new(
+        file_storer.clone(),
+        repository.clone(),
+        local_message_exchange.new_sender(),
+    ));
 
     let sharing = Arc::new(SharingService::new(
         Arc::new(TelegramBot::new(&get_telegram_chat_id(), &get_telegram_token())),
         repository.clone(),
-        spawner.clone()
+        spawner.clone(),
     ));
-    
+
     Ok(Context::new(
         Arc::new(MediaStore::new(file_storer, repository.clone())),
         search_service,
@@ -163,6 +202,68 @@ pub async fn create_context() -> anyhow::Result<Context> {
         repository,
         checker,
         local_message_exchange,
-        Some(sharing)
+        book_store,
+        book_file_storer,
+        Some(sharing),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, sync::Arc};
+
+    use crate::{
+        adaptors::{FileSystemStore, SqlRepository},
+        domain::{
+            messagebus::{LocalMessageExchange, MessageExchange, MessageFilter},
+            traits::{FileStorer, MockMediaChecker, MockMediaStorer, Repository, Storer},
+            NoSpawner,
+        },
+        services::{BookStore, SearchService, TaskManager},
+    };
+
+    use super::Context;
+
+    #[tokio::test]
+    async fn context_exposes_injected_book_store_and_book_file_store() {
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let task_manager = Arc::new(TaskManager::new(Arc::new(NoSpawner::new())));
+        let search = SearchService::new(task_manager.clone(), Vec::new(), repository.clone());
+        let local_message_exchange = LocalMessageExchange::new();
+        let messenger = MessageExchange::new(
+            local_message_exchange.new_sender(),
+            local_message_exchange
+                .listen_for_messages(MessageFilter::All)
+                .await
+                .unwrap(),
+        );
+        let media_store: Storer = Arc::new(MockMediaStorer::new());
+        let checker = Arc::new(MockMediaChecker::new());
+        let book_files: FileStorer = Arc::new(FileSystemStore::new("/tmp/context-books"));
+        let thumbnail_files: FileStorer =
+            Arc::new(FileSystemStore::new("/tmp/context-book-thumbnails"));
+        let book_store = Arc::new(BookStore::new_with_roots(
+            book_files.clone(),
+            thumbnail_files,
+            repository.clone(),
+            Path::new("/tmp/context-books"),
+            Path::new("/tmp/context-book-thumbnails"),
+        ));
+
+        let context = Context::new(
+            media_store,
+            search,
+            messenger,
+            task_manager,
+            repository,
+            checker,
+            local_message_exchange,
+            book_store.clone(),
+            book_files.clone(),
+            None,
+        );
+
+        assert!(Arc::ptr_eq(&context.get_book_store(), &book_store));
+        assert!(Arc::ptr_eq(&context.get_book_file_storer(), &book_files));
+    }
 }

--- a/src/entrypoints/context.rs
+++ b/src/entrypoints/context.rs
@@ -171,9 +171,14 @@ pub async fn create_context() -> anyhow::Result<Context> {
     let book_dir = get_book_dir();
     let book_thumbnail_dir = get_book_thumbnail_dir(&book_dir);
     let book_file_storer: FileStorer = Arc::new(FileSystemStore::new(&book_dir));
-    let book_thumbnail_file_storer: FileStorer = Arc::new(FileSystemStore::new(
-        book_thumbnail_dir.to_str().unwrap_or_default(),
-    ));
+    let book_thumbnail_dir_string = book_thumbnail_dir.to_str().ok_or_else(|| {
+        anyhow::anyhow!(
+            "configured book thumbnail directory is not valid UTF-8: {}",
+            book_thumbnail_dir.display()
+        )
+    })?;
+    let book_thumbnail_file_storer: FileStorer =
+        Arc::new(FileSystemStore::new(book_thumbnail_dir_string));
     let book_store = Arc::new(BookStore::new_with_roots(
         book_file_storer.clone(),
         book_thumbnail_file_storer,

--- a/src/services/book_store.rs
+++ b/src/services/book_store.rs
@@ -97,21 +97,29 @@ impl BookStore {
             return String::new();
         };
 
-        parent
-            .strip_prefix(&self.book_root)
-            .ok()
-            .filter(|relative| !relative.as_os_str().is_empty())
-            .or_else(|| parent.file_name().map(Path::new))
-            .and_then(Path::to_str)
-            .unwrap_or_default()
-            .to_string()
+        match parent.strip_prefix(&self.book_root) {
+            Ok(relative) => relative.to_str().unwrap_or_default().to_string(),
+            Err(_) => parent
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string(),
+        }
     }
 
     pub async fn delete(&self, checksum: i64) -> Result<()> {
         let book = self.repo.retrieve_book(checksum).await?;
+        let collection = safe_relative_collection(&book.collection)?;
+        let file_name = safe_file_name(&book.file_name, "book file")?;
+        let thumbnail = safe_file_name(&book.thumbnail, "book thumbnail")?;
+
+        let book_path = self.book_root.join(collection).join(file_name);
+        self.store
+            .delete(book_path.to_str().unwrap_or_default())
+            .await?;
 
         if !is_default_book_thumbnail(&book.thumbnail) {
-            let thumbnail_path = self.thumbnail_root.join(&book.thumbnail);
+            let thumbnail_path = self.thumbnail_root.join(thumbnail);
             if let Err(error) = self
                 .thumbnail_store
                 .delete(thumbnail_path.to_str().unwrap_or_default())
@@ -125,12 +133,18 @@ impl BookStore {
             }
         }
 
-        let book_path = self.book_root.join(book.get_download_path());
-        self.store
-            .delete(book_path.to_str().unwrap_or_default())
-            .await?;
         self.repo.delete_book(checksum).await?;
         Ok(())
+    }
+}
+
+fn safe_file_name(file_name: &str, description: &str) -> Result<PathBuf> {
+    let mut components = Path::new(file_name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(name)), None) => Ok(PathBuf::from(name)),
+        _ => Err(anyhow::anyhow!(
+            "{description} must be a single file name without traversal: {file_name}"
+        )),
     }
 }
 
@@ -307,6 +321,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn add_file_without_derivable_collection_stays_at_book_root() {
+        let layout = TestLayout::new("root-fallback");
+        let source = layout.book_root.join("Root.epub");
+        tokio::fs::write(&source, b"book").await.unwrap();
+        let (store, _) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+
+        let destination = store.add_file(&source, None).await.unwrap();
+
+        assert_eq!(destination, source);
+        assert_eq!(tokio::fs::read(&source).await.unwrap(), b"book");
+        assert!(!layout.book_root.join("books/Root.epub").exists());
+    }
+
+    #[tokio::test]
     async fn add_file_rejects_collection_path_traversal_without_creating_directories() {
         let layout = TestLayout::new("add-traversal");
         let source = layout.source_root.join("Secrets.epub");
@@ -400,26 +428,66 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_does_not_follow_persisted_paths_outside_roots() {
-        let layout = TestLayout::new("delete-traversal");
-        let outside_book = layout.base.join("outside.epub");
-        let outside_thumbnail = layout.base.join("outside.jpg");
-        tokio::fs::write(&outside_book, b"keep book").await.unwrap();
-        tokio::fs::write(&outside_thumbnail, b"keep cover")
+    async fn primary_book_delete_failure_preserves_thumbnail_and_repository_row() {
+        let layout = TestLayout::new("primary-delete-failure");
+        let undeletable_book = layout.book_root.join("Fiction/Dune.epub");
+        tokio::fs::create_dir_all(&undeletable_book).await.unwrap();
+        let thumbnail_path = layout.thumbnail_root.join("dune-cover.jpg");
+        tokio::fs::write(&thumbnail_path, b"keep cover")
             .await
             .unwrap();
         let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
-        let mut book = sample_book(13, "../", "../outside.epub");
-        book.thumbnail = "../outside.jpg".to_string();
+        let mut book = sample_book(15, "Fiction", "Dune.epub");
+        book.thumbnail = "dune-cover.jpg".to_string();
         repository.save_book(&book).await.unwrap();
 
-        store.delete(book.checksum).await.unwrap();
+        let result = store.delete(book.checksum).await;
 
-        assert_eq!(tokio::fs::read(&outside_book).await.unwrap(), b"keep book");
-        assert_eq!(tokio::fs::read(&outside_thumbnail).await.unwrap(), b"keep cover");
-        assert!(matches!(
-            repository.retrieve_book(book.checksum).await,
-            Err(sqlx::Error::RowNotFound)
-        ));
+        assert!(result.is_err());
+        assert_eq!(tokio::fs::read(&thumbnail_path).await.unwrap(), b"keep cover");
+        assert!(repository.retrieve_book(book.checksum).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn delete_rejects_malformed_book_identity_without_deleting_in_root_alias() {
+        let layout = TestLayout::new("delete-book-alias");
+        let victim_book = layout.book_root.join("victim.epub");
+        tokio::fs::write(&victim_book, b"keep book").await.unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let book = sample_book(13, "../", "../victim.epub");
+        repository.save_book(&book).await.unwrap();
+
+        let result = store.delete(book.checksum).await;
+
+        assert!(result.is_err());
+        assert_eq!(tokio::fs::read(&victim_book).await.unwrap(), b"keep book");
+        assert!(repository.retrieve_book(book.checksum).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn delete_rejects_malformed_thumbnail_without_deleting_in_root_alias() {
+        let layout = TestLayout::new("delete-thumbnail-alias");
+        let book_path = layout.book_root.join("Bad.epub");
+        tokio::fs::write(&book_path, b"keep malformed book")
+            .await
+            .unwrap();
+        let victim_thumbnail = layout.thumbnail_root.join("victim.jpg");
+        tokio::fs::write(&victim_thumbnail, b"keep cover")
+            .await
+            .unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let mut book = sample_book(14, "", "Bad.epub");
+        book.thumbnail = "subdir/../victim.jpg".to_string();
+        repository.save_book(&book).await.unwrap();
+
+        let result = store.delete(book.checksum).await;
+
+        assert!(result.is_err());
+        assert_eq!(tokio::fs::read(&victim_thumbnail).await.unwrap(), b"keep cover");
+        assert_eq!(
+            tokio::fs::read(&book_path).await.unwrap(),
+            b"keep malformed book"
+        );
+        assert!(repository.retrieve_book(book.checksum).await.is_ok());
     }
 }

--- a/src/services/book_store.rs
+++ b/src/services/book_store.rs
@@ -111,7 +111,6 @@ impl BookStore {
         let book = self.repo.retrieve_book(checksum).await?;
         let collection = safe_relative_collection(&book.collection)?;
         let file_name = safe_file_name(&book.file_name, "book file")?;
-        let thumbnail = safe_file_name(&book.thumbnail, "book thumbnail")?;
 
         let book_path = self.book_root.join(collection).join(file_name);
         self.store
@@ -119,17 +118,29 @@ impl BookStore {
             .await?;
 
         if !is_default_book_thumbnail(&book.thumbnail) {
-            let thumbnail_path = self.thumbnail_root.join(thumbnail);
-            if let Err(error) = self
-                .thumbnail_store
-                .delete(thumbnail_path.to_str().unwrap_or_default())
-                .await
-            {
-                tracing::warn!(
-                    "Failed to delete book thumbnail {}: {}",
-                    thumbnail_path.display(),
-                    error
-                );
+            let unvalidated_path = self.thumbnail_root.join(&book.thumbnail);
+            match safe_file_name(&book.thumbnail, "book thumbnail") {
+                Ok(thumbnail) => {
+                    let thumbnail_path = self.thumbnail_root.join(thumbnail);
+                    if let Err(error) = self
+                        .thumbnail_store
+                        .delete(thumbnail_path.to_str().unwrap_or_default())
+                        .await
+                    {
+                        tracing::warn!(
+                            "Failed to delete book thumbnail {}: {}",
+                            thumbnail_path.display(),
+                            error
+                        );
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        "Failed to delete book thumbnail {}: {}",
+                        unvalidated_path.display(),
+                        error
+                    );
+                }
             }
         }
 
@@ -139,9 +150,19 @@ impl BookStore {
 }
 
 fn safe_file_name(file_name: &str, description: &str) -> Result<PathBuf> {
-    let mut components = Path::new(file_name).components();
+    let original = Path::new(file_name);
+    let mut components = original.components();
     match (components.next(), components.next()) {
-        (Some(Component::Normal(name)), None) => Ok(PathBuf::from(name)),
+        (Some(Component::Normal(name)), None) => {
+            let canonical = PathBuf::from(name);
+            if original.as_os_str() == canonical.as_os_str() {
+                Ok(canonical)
+            } else {
+                Err(anyhow::anyhow!(
+                    "{description} must already be canonical: {file_name}"
+                ))
+            }
+        }
         _ => Err(anyhow::anyhow!(
             "{description} must be a single file name without traversal: {file_name}"
         )),
@@ -149,8 +170,9 @@ fn safe_file_name(file_name: &str, description: &str) -> Result<PathBuf> {
 }
 
 fn safe_relative_collection(collection: &str) -> Result<PathBuf> {
+    let original = Path::new(collection);
     let mut relative = PathBuf::new();
-    for component in Path::new(collection).components() {
+    for component in original.components() {
         match component {
             Component::Normal(part) => relative.push(part),
             _ => {
@@ -160,7 +182,13 @@ fn safe_relative_collection(collection: &str) -> Result<PathBuf> {
             }
         }
     }
-    Ok(relative)
+    if original.as_os_str() == relative.as_os_str() {
+        Ok(relative)
+    } else {
+        Err(anyhow::anyhow!(
+            "book collection must already be canonical: {collection}"
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -465,7 +493,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_rejects_malformed_thumbnail_without_deleting_in_root_alias() {
+    async fn delete_rejects_noncanonical_primary_identities_without_deleting_aliases() {
+        for (label, checksum, collection, file_name, victim_relative) in [
+            (
+                "collection-dot",
+                21,
+                "Fiction/./Classics",
+                "victim.epub",
+                "Fiction/Classics/victim.epub",
+            ),
+            (
+                "collection-repeat",
+                22,
+                "Fiction//Classics",
+                "victim.epub",
+                "Fiction/Classics/victim.epub",
+            ),
+            (
+                "collection-trailing",
+                23,
+                "Fiction/Classics/",
+                "victim.epub",
+                "Fiction/Classics/victim.epub",
+            ),
+            ("file-trailing", 24, "", "victim.epub/", "victim.epub"),
+        ] {
+            let layout = TestLayout::new(label);
+            let victim_book = layout.book_root.join(victim_relative);
+            tokio::fs::create_dir_all(victim_book.parent().unwrap())
+                .await
+                .unwrap();
+            tokio::fs::write(&victim_book, b"keep canonical book")
+                .await
+                .unwrap();
+            let (store, repository) =
+                store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+            let book = sample_book(checksum, collection, file_name);
+            repository.save_book(&book).await.unwrap();
+
+            let result = store.delete(book.checksum).await;
+
+            assert!(result.is_err(), "{label} should be rejected");
+            assert_eq!(
+                tokio::fs::read(&victim_book).await.unwrap(),
+                b"keep canonical book",
+                "{label} deleted its canonical alias"
+            );
+            assert!(
+                repository.retrieve_book(book.checksum).await.is_ok(),
+                "{label} removed the malformed row"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_thumbnail_cleanup_does_not_prevent_book_and_row_deletion() {
         let layout = TestLayout::new("delete-thumbnail-alias");
         let book_path = layout.book_root.join("Bad.epub");
         tokio::fs::write(&book_path, b"keep malformed book")
@@ -482,12 +564,12 @@ mod tests {
 
         let result = store.delete(book.checksum).await;
 
-        assert!(result.is_err());
+        assert!(result.is_ok());
         assert_eq!(tokio::fs::read(&victim_thumbnail).await.unwrap(), b"keep cover");
-        assert_eq!(
-            tokio::fs::read(&book_path).await.unwrap(),
-            b"keep malformed book"
-        );
-        assert!(repository.retrieve_book(book.checksum).await.is_ok());
+        assert!(!book_path.exists());
+        assert!(matches!(
+            repository.retrieve_book(book.checksum).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
     }
 }

--- a/src/services/book_store.rs
+++ b/src/services/book_store.rs
@@ -1,0 +1,425 @@
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::domain::{
+    algorithm::title_case,
+    config::{get_book_dir, get_book_thumbnail_dir},
+    models::{
+        is_default_book_thumbnail, BookCollectionDetails, BookCollectionItem,
+        DEFAULT_BOOK_THUMBNAIL,
+    },
+    traits::{FileStorer, Repository},
+};
+
+#[derive(Clone)]
+pub struct BookStore {
+    store: FileStorer,
+    thumbnail_store: FileStorer,
+    repo: Repository,
+    book_root: PathBuf,
+    thumbnail_root: PathBuf,
+}
+
+impl BookStore {
+    pub fn new(store: FileStorer, thumbnail_store: FileStorer, repo: Repository) -> Self {
+        let book_root = PathBuf::from(get_book_dir());
+        let thumbnail_root = get_book_thumbnail_dir(book_root.to_str().unwrap_or_default());
+        Self::new_with_roots(store, thumbnail_store, repo, book_root, thumbnail_root)
+    }
+
+    pub fn new_with_roots(
+        store: FileStorer,
+        thumbnail_store: FileStorer,
+        repo: Repository,
+        book_root: impl AsRef<Path>,
+        thumbnail_root: impl AsRef<Path>,
+    ) -> Self {
+        Self {
+            store,
+            thumbnail_store,
+            repo,
+            book_root: book_root.as_ref().to_path_buf(),
+            thumbnail_root: thumbnail_root.as_ref().to_path_buf(),
+        }
+    }
+
+    pub async fn list(&self, collection: &str) -> Result<BookCollectionDetails> {
+        let child_collections = self
+            .repo
+            .list_book_collections(collection)
+            .await?
+            .into_iter()
+            .map(|collection| BookCollectionItem {
+                collection,
+                thumbnail: DEFAULT_BOOK_THUMBNAIL.to_string(),
+            })
+            .collect();
+        let books = self.repo.list_books(collection).await?;
+
+        Ok(BookCollectionDetails::new(
+            collection.to_string(),
+            child_collections,
+            books,
+        ))
+    }
+
+    pub async fn add_file(
+        &self,
+        full_path: &Path,
+        suggested_collection: Option<String>,
+    ) -> Result<PathBuf> {
+        let collection = suggested_collection
+            .map(|collection| title_case(&collection))
+            .unwrap_or_else(|| self.collection_from_source(full_path));
+        let collection = safe_relative_collection(&collection)?;
+        let destination_directory = self.book_root.join(collection);
+        self.store.create_folder(&destination_directory).await?;
+        let destination = destination_directory.join(full_path.file_name().ok_or_else(|| {
+            anyhow::anyhow!("book path has no file name: {}", full_path.display())
+        })?);
+
+        if full_path == destination {
+            return Ok(destination);
+        }
+
+        self.store
+            .rename(
+                full_path.to_str().unwrap_or_default(),
+                destination.to_str().unwrap_or_default(),
+            )
+            .await?;
+        Ok(destination)
+    }
+
+    fn collection_from_source(&self, full_path: &Path) -> String {
+        let Some(parent) = full_path.parent() else {
+            return String::new();
+        };
+
+        parent
+            .strip_prefix(&self.book_root)
+            .ok()
+            .filter(|relative| !relative.as_os_str().is_empty())
+            .or_else(|| parent.file_name().map(Path::new))
+            .and_then(Path::to_str)
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    pub async fn delete(&self, checksum: i64) -> Result<()> {
+        let book = self.repo.retrieve_book(checksum).await?;
+
+        if !is_default_book_thumbnail(&book.thumbnail) {
+            let thumbnail_path = self.thumbnail_root.join(&book.thumbnail);
+            if let Err(error) = self
+                .thumbnail_store
+                .delete(thumbnail_path.to_str().unwrap_or_default())
+                .await
+            {
+                tracing::warn!(
+                    "Failed to delete book thumbnail {}: {}",
+                    thumbnail_path.display(),
+                    error
+                );
+            }
+        }
+
+        let book_path = self.book_root.join(book.get_download_path());
+        self.store
+            .delete(book_path.to_str().unwrap_or_default())
+            .await?;
+        self.repo.delete_book(checksum).await?;
+        Ok(())
+    }
+}
+
+fn safe_relative_collection(collection: &str) -> Result<PathBuf> {
+    let mut relative = PathBuf::new();
+    for component in Path::new(collection).components() {
+        match component {
+            Component::Normal(part) => relative.push(part),
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "book collection must be a relative path without traversal: {collection}"
+                ));
+            }
+        }
+    }
+    Ok(relative)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::{Path, PathBuf},
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc,
+        },
+    };
+
+    use chrono::Local;
+
+    use crate::{
+        adaptors::{FileSystemStore, SqlRepository},
+        domain::{
+            models::{BookDetails, BookFormat, BookState, DEFAULT_BOOK_THUMBNAIL},
+            traits::{FileStorer, Repository},
+        },
+    };
+
+    use super::BookStore;
+
+    static NEXT_TEST_DIR: AtomicU64 = AtomicU64::new(0);
+
+    struct TestLayout {
+        base: PathBuf,
+        source_root: PathBuf,
+        book_root: PathBuf,
+        thumbnail_root: PathBuf,
+        movie_root: PathBuf,
+    }
+
+    impl TestLayout {
+        fn new(label: &str) -> Self {
+            let id = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
+            let base = std::env::temp_dir().join(format!(
+                "tvserver-book-store-{label}-{}-{id}",
+                std::process::id()
+            ));
+            let layout = Self {
+                source_root: base.join("downloads"),
+                book_root: base.join("books"),
+                thumbnail_root: base.join("book-thumbnails"),
+                movie_root: base.join("movies"),
+                base,
+            };
+            for directory in
+                [&layout.source_root, &layout.book_root, &layout.thumbnail_root, &layout.movie_root]
+            {
+                std::fs::create_dir_all(directory).unwrap();
+            }
+            layout
+        }
+    }
+
+    impl Drop for TestLayout {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.base);
+        }
+    }
+
+    fn sample_book(checksum: i64, collection: &str, file_name: &str) -> BookDetails {
+        let now = Local::now().naive_local();
+        BookDetails {
+            file_name: file_name.to_string(),
+            collection: collection.to_string(),
+            title: file_name.trim_end_matches(".epub").to_string(),
+            format: BookFormat::Epub,
+            thumbnail: DEFAULT_BOOK_THUMBNAIL.to_string(),
+            checksum,
+            state: BookState::Ready,
+            created_on: now,
+            updated_on: now,
+            ..BookDetails::default()
+        }
+    }
+
+    async fn store_for_roots(book_root: &Path, thumbnail_root: &Path) -> (BookStore, Repository) {
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let book_files: FileStorer = Arc::new(FileSystemStore::new(
+            book_root.to_str().expect("book root should be UTF-8"),
+        ));
+        let thumbnail_files: FileStorer = Arc::new(FileSystemStore::new(
+            thumbnail_root
+                .to_str()
+                .expect("thumbnail root should be UTF-8"),
+        ));
+        (
+            BookStore::new_with_roots(
+                book_files,
+                thumbnail_files,
+                repository.clone(),
+                book_root,
+                thumbnail_root,
+            ),
+            repository,
+        )
+    }
+
+    #[tokio::test]
+    async fn list_returns_child_collections_and_books() {
+        let book_root = Path::new("/tmp/tvserver-book-store-list-books");
+        let thumbnail_root = Path::new("/tmp/tvserver-book-store-list-thumbnails");
+        let (store, repository) = store_for_roots(book_root, thumbnail_root).await;
+        repository
+            .save_book(&sample_book(1, "Fiction", "Dune.epub"))
+            .await
+            .unwrap();
+        repository
+            .save_book(&sample_book(2, "Fiction/Classics", "Emma.epub"))
+            .await
+            .unwrap();
+
+        let result = store.list("Fiction").await.unwrap();
+
+        assert_eq!(result.collection, "Fiction");
+        assert_eq!(result.books.len(), 1);
+        assert_eq!(result.books[0].file_name, "Dune.epub");
+        assert_eq!(result.child_collections.len(), 1);
+        assert_eq!(result.child_collections[0].collection, "Classics");
+        assert_eq!(result.child_collections[0].thumbnail, DEFAULT_BOOK_THUMBNAIL);
+    }
+
+    #[tokio::test]
+    async fn add_file_uses_suggested_collection_under_book_root() {
+        let layout = TestLayout::new("suggested-collection");
+        let source = layout.source_root.join("Dune.epub");
+        tokio::fs::write(&source, b"book").await.unwrap();
+        let (store, _) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+
+        let destination = store
+            .add_file(&source, Some("science fiction".to_string()))
+            .await
+            .unwrap();
+
+        assert_eq!(destination, layout.book_root.join("Science Fiction/Dune.epub"));
+        assert!(destination.exists());
+        assert!(!source.exists());
+        assert!(!layout.movie_root.join("Science Fiction/Dune.epub").exists());
+    }
+
+    #[tokio::test]
+    async fn add_file_derives_collection_from_source_parent() {
+        let layout = TestLayout::new("derived-collection");
+        let source_directory = layout.source_root.join("Classics");
+        tokio::fs::create_dir_all(&source_directory).await.unwrap();
+        let source = source_directory.join("Emma.epub");
+        tokio::fs::write(&source, b"book").await.unwrap();
+        let (store, _) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+
+        let destination = store.add_file(&source, None).await.unwrap();
+
+        assert_eq!(destination, layout.book_root.join("Classics/Emma.epub"));
+        assert!(destination.exists());
+        assert!(!source.exists());
+    }
+
+    #[tokio::test]
+    async fn add_file_rejects_collection_path_traversal_without_creating_directories() {
+        let layout = TestLayout::new("add-traversal");
+        let source = layout.source_root.join("Secrets.epub");
+        tokio::fs::write(&source, b"book").await.unwrap();
+        let (store, _) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let escaped_directory = layout.base.join("escaped");
+
+        let result = store
+            .add_file(&source, Some("../escaped".to_string()))
+            .await;
+
+        assert!(result.is_err());
+        assert!(source.exists());
+        assert!(!escaped_directory.exists());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_book_generated_thumbnail_and_repository_row() {
+        let layout = TestLayout::new("delete-generated-thumbnail");
+        let book_path = layout.book_root.join("Fiction/Dune.epub");
+        tokio::fs::create_dir_all(book_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&book_path, b"book").await.unwrap();
+        let thumbnail_path = layout.thumbnail_root.join("dune-cover.jpg");
+        tokio::fs::write(&thumbnail_path, b"cover").await.unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let mut book = sample_book(10, "Fiction", "Dune.epub");
+        book.thumbnail = "dune-cover.jpg".to_string();
+        repository.save_book(&book).await.unwrap();
+
+        store.delete(book.checksum).await.unwrap();
+
+        assert!(!book_path.exists());
+        assert!(!thumbnail_path.exists());
+        assert!(matches!(
+            repository.retrieve_book(book.checksum).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn delete_preserves_default_thumbnail() {
+        let layout = TestLayout::new("delete-default-thumbnail");
+        let book_path = layout.book_root.join("Fiction/Dune.epub");
+        tokio::fs::create_dir_all(book_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&book_path, b"book").await.unwrap();
+        let default_thumbnail_path = layout.thumbnail_root.join(DEFAULT_BOOK_THUMBNAIL);
+        tokio::fs::write(&default_thumbnail_path, b"default cover")
+            .await
+            .unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let book = sample_book(11, "Fiction", "Dune.epub");
+        repository.save_book(&book).await.unwrap();
+
+        store.delete(book.checksum).await.unwrap();
+
+        assert!(!book_path.exists());
+        assert!(default_thumbnail_path.exists());
+        assert!(matches!(
+            repository.retrieve_book(book.checksum).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn thumbnail_cleanup_failure_does_not_prevent_book_and_row_deletion() {
+        let layout = TestLayout::new("thumbnail-cleanup-failure");
+        let book_path = layout.book_root.join("Fiction/Dune.epub");
+        tokio::fs::create_dir_all(book_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&book_path, b"book").await.unwrap();
+        let undeletable_thumbnail = layout.thumbnail_root.join("cover-directory");
+        tokio::fs::create_dir(&undeletable_thumbnail).await.unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let mut book = sample_book(12, "Fiction", "Dune.epub");
+        book.thumbnail = "cover-directory".to_string();
+        repository.save_book(&book).await.unwrap();
+
+        store.delete(book.checksum).await.unwrap();
+
+        assert!(!book_path.exists());
+        assert!(undeletable_thumbnail.exists());
+        assert!(matches!(
+            repository.retrieve_book(book.checksum).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn delete_does_not_follow_persisted_paths_outside_roots() {
+        let layout = TestLayout::new("delete-traversal");
+        let outside_book = layout.base.join("outside.epub");
+        let outside_thumbnail = layout.base.join("outside.jpg");
+        tokio::fs::write(&outside_book, b"keep book").await.unwrap();
+        tokio::fs::write(&outside_thumbnail, b"keep cover")
+            .await
+            .unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let mut book = sample_book(13, "../", "../outside.epub");
+        book.thumbnail = "../outside.jpg".to_string();
+        repository.save_book(&book).await.unwrap();
+
+        store.delete(book.checksum).await.unwrap();
+
+        assert_eq!(tokio::fs::read(&outside_book).await.unwrap(), b"keep book");
+        assert_eq!(tokio::fs::read(&outside_thumbnail).await.unwrap(), b"keep cover");
+        assert!(matches!(
+            repository.retrieve_book(book.checksum).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+    }
+}

--- a/src/services/book_store.rs
+++ b/src/services/book_store.rs
@@ -23,8 +23,9 @@ pub struct BookStore {
 
 impl BookStore {
     pub fn new(store: FileStorer, thumbnail_store: FileStorer, repo: Repository) -> Self {
-        let book_root = PathBuf::from(get_book_dir());
-        let thumbnail_root = get_book_thumbnail_dir(book_root.to_str().unwrap_or_default());
+        let configured_book_root = get_book_dir();
+        let thumbnail_root = get_book_thumbnail_dir(&configured_book_root);
+        let book_root = PathBuf::from(configured_book_root);
         Self::new_with_roots(store, thumbnail_store, repo, book_root, thumbnail_root)
     }
 
@@ -69,41 +70,64 @@ impl BookStore {
         full_path: &Path,
         suggested_collection: Option<String>,
     ) -> Result<PathBuf> {
-        let collection = suggested_collection
-            .map(|collection| title_case(&collection))
-            .unwrap_or_else(|| self.collection_from_source(full_path));
+        let collection = match suggested_collection {
+            Some(collection) => title_case(&collection),
+            None => self.collection_from_source(full_path)?,
+        };
         let collection = safe_relative_collection(&collection)?;
         let destination_directory = self.book_root.join(collection);
-        self.store.create_folder(&destination_directory).await?;
+        let source_path = full_path.to_str().ok_or_else(|| {
+            anyhow::anyhow!("book source path is not valid UTF-8: {}", full_path.display())
+        })?;
         let destination = destination_directory.join(full_path.file_name().ok_or_else(|| {
             anyhow::anyhow!("book path has no file name: {}", full_path.display())
         })?);
+        let destination_path = destination.to_str().ok_or_else(|| {
+            anyhow::anyhow!(
+                "book destination path is not valid UTF-8: {}",
+                destination.display()
+            )
+        })?;
+        ensure_path_within_root(
+            &destination_directory,
+            &self.book_root,
+            "book destination directory",
+        )
+        .await?;
+        self.store.create_folder(&destination_directory).await?;
 
-        if full_path == destination {
-            return Ok(destination);
+        let comparable_source = absolute_path(full_path, "book source")?;
+        let comparable_destination = absolute_path(&destination, "book destination")?;
+        if comparable_source == comparable_destination {
+            return Ok(full_path.to_path_buf());
         }
 
-        self.store
-            .rename(
-                full_path.to_str().unwrap_or_default(),
-                destination.to_str().unwrap_or_default(),
-            )
-            .await?;
+        self.store.rename(source_path, destination_path).await?;
         Ok(destination)
     }
 
-    fn collection_from_source(&self, full_path: &Path) -> String {
+    fn collection_from_source(&self, full_path: &Path) -> Result<String> {
         let Some(parent) = full_path.parent() else {
-            return String::new();
+            return Ok(String::new());
         };
+        let comparable_parent = absolute_path(parent, "book source parent")?;
+        let comparable_root = absolute_path(&self.book_root, "configured book root")?;
 
-        match parent.strip_prefix(&self.book_root) {
-            Ok(relative) => relative.to_str().unwrap_or_default().to_string(),
-            Err(_) => parent
+        match comparable_parent.strip_prefix(comparable_root) {
+            Ok(relative) => relative
+                .to_str()
+                .map(str::to_string)
+                .ok_or_else(|| anyhow::anyhow!("book collection path is not valid UTF-8")),
+            Err(_) => comparable_parent
                 .file_name()
                 .and_then(|name| name.to_str())
-                .unwrap_or_default()
-                .to_string(),
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "book source parent is not valid UTF-8: {}",
+                        comparable_parent.display()
+                    )
+                }),
         }
     }
 
@@ -113,20 +137,34 @@ impl BookStore {
         let file_name = safe_file_name(&book.file_name, "book file")?;
 
         let book_path = self.book_root.join(collection).join(file_name);
-        self.store
-            .delete(book_path.to_str().unwrap_or_default())
-            .await?;
+        let book_path_string = book_path.to_str().ok_or_else(|| {
+            anyhow::anyhow!("book file path is not valid UTF-8: {}", book_path.display())
+        })?;
+        ensure_path_within_root(&book_path, &self.book_root, "book file").await?;
+        self.store.delete(book_path_string).await?;
 
         if !is_default_book_thumbnail(&book.thumbnail) {
             let unvalidated_path = self.thumbnail_root.join(&book.thumbnail);
             match safe_file_name(&book.thumbnail, "book thumbnail") {
                 Ok(thumbnail) => {
                     let thumbnail_path = self.thumbnail_root.join(thumbnail);
-                    if let Err(error) = self
-                        .thumbnail_store
-                        .delete(thumbnail_path.to_str().unwrap_or_default())
-                        .await
-                    {
+                    let cleanup_result = async {
+                        ensure_path_within_root(
+                            &thumbnail_path,
+                            &self.thumbnail_root,
+                            "book thumbnail",
+                        )
+                        .await?;
+                        let thumbnail_path_string = thumbnail_path.to_str().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "book thumbnail path is not valid UTF-8: {}",
+                                thumbnail_path.display()
+                            )
+                        })?;
+                        self.thumbnail_store.delete(thumbnail_path_string).await
+                    }
+                    .await;
+                    if let Err(error) = cleanup_result {
                         tracing::warn!(
                             "Failed to delete book thumbnail {}: {}",
                             thumbnail_path.display(),
@@ -146,6 +184,66 @@ impl BookStore {
 
         self.repo.delete_book(checksum).await?;
         Ok(())
+    }
+}
+
+fn absolute_path(path: &Path, description: &str) -> Result<PathBuf> {
+    std::path::absolute(path).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to make {description} absolute ({}): {error}",
+            path.display()
+        )
+    })
+}
+
+async fn ensure_path_within_root(path: &Path, root: &Path, description: &str) -> Result<()> {
+    let resolved_root = resolve_existing_path_prefix(root).await?;
+    let resolved_path = resolve_existing_path_prefix(path).await?;
+    if resolved_path.starts_with(&resolved_root) {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "{description} escapes configured root: {}",
+            path.display()
+        ))
+    }
+}
+
+async fn resolve_existing_path_prefix(path: &Path) -> Result<PathBuf> {
+    let absolute = absolute_path(path, "path boundary")?;
+    let mut current = absolute.clone();
+    let mut missing = Vec::new();
+
+    loop {
+        match tokio::fs::canonicalize(&current).await {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let component = current.file_name().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "failed to resolve an existing path prefix for {}",
+                        absolute.display()
+                    )
+                })?;
+                missing.push(component.to_os_string());
+                current = current.parent().map(Path::to_path_buf).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "failed to resolve an existing path prefix for {}",
+                        absolute.display()
+                    )
+                })?;
+            }
+            Err(error) => {
+                return Err(anyhow::anyhow!(
+                    "failed to resolve path boundary for {}: {error}",
+                    path.display()
+                ));
+            }
+        }
     }
 }
 
@@ -363,6 +461,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn absolute_source_at_relative_book_root_does_not_duplicate_collection() {
+        let id = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
+        let relative_base = PathBuf::from("target").join(format!(
+            "tvserver-book-store-relative-root-{}-{id}",
+            std::process::id()
+        ));
+        let absolute_base = std::env::current_dir().unwrap().join(&relative_base);
+        let layout = TestLayout {
+            base: absolute_base.clone(),
+            source_root: absolute_base.join("downloads"),
+            book_root: relative_base.join("books"),
+            thumbnail_root: relative_base.join("book-thumbnails"),
+            movie_root: absolute_base.join("movies"),
+        };
+        tokio::fs::create_dir_all(absolute_base.join("books"))
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(absolute_base.join("book-thumbnails"))
+            .await
+            .unwrap();
+        let source = absolute_base.join("books/Root.epub");
+        tokio::fs::write(&source, b"book").await.unwrap();
+        let (store, _) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+
+        let destination = store.add_file(&source, None).await.unwrap();
+
+        assert_eq!(destination, source);
+        assert_eq!(tokio::fs::read(&source).await.unwrap(), b"book");
+        assert!(!absolute_base.join("books/books/Root.epub").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn add_file_rejects_non_utf8_source_before_filesystem_writes() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let layout = TestLayout::new("non-utf8-source");
+        let source = layout
+            .source_root
+            .join(OsString::from_vec(b"Dune-\xff.epub".to_vec()));
+        let (store, _) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+
+        let error = store
+            .add_file(&source, Some("Fiction".to_string()))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("not valid UTF-8"));
+        assert!(!layout.book_root.join("Fiction").exists());
+    }
+
+    #[tokio::test]
     async fn add_file_rejects_collection_path_traversal_without_creating_directories() {
         let layout = TestLayout::new("add-traversal");
         let source = layout.source_root.join("Secrets.epub");
@@ -377,6 +527,26 @@ mod tests {
         assert!(result.is_err());
         assert!(source.exists());
         assert!(!escaped_directory.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn add_file_rejects_collection_symlink_that_escapes_book_root() {
+        use std::os::unix::fs::symlink;
+
+        let layout = TestLayout::new("add-symlink-escape");
+        let outside = layout.base.join("outside-add");
+        tokio::fs::create_dir(&outside).await.unwrap();
+        symlink(&outside, layout.book_root.join("Fiction")).unwrap();
+        let source = layout.source_root.join("Dune.epub");
+        tokio::fs::write(&source, b"book").await.unwrap();
+        let (store, _) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+
+        let result = store.add_file(&source, Some("Fiction".to_string())).await;
+
+        assert!(result.is_err());
+        assert!(source.exists());
+        assert!(!outside.join("Dune.epub").exists());
     }
 
     #[tokio::test]
@@ -455,6 +625,42 @@ mod tests {
         ));
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn thumbnail_symlink_escape_is_warning_only_and_row_deletion_continues() {
+        use std::os::unix::fs::symlink;
+
+        let layout = TestLayout::new("thumbnail-symlink-escape");
+        let book_path = layout.book_root.join("Fiction/Dune.epub");
+        tokio::fs::create_dir_all(book_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&book_path, b"book").await.unwrap();
+        let outside_thumbnail = layout.base.join("outside-cover.jpg");
+        tokio::fs::write(&outside_thumbnail, b"keep outside cover")
+            .await
+            .unwrap();
+        let thumbnail_link = layout.thumbnail_root.join("dune-cover.jpg");
+        symlink(&outside_thumbnail, &thumbnail_link).unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let mut book = sample_book(32, "Fiction", "Dune.epub");
+        book.thumbnail = "dune-cover.jpg".to_string();
+        repository.save_book(&book).await.unwrap();
+
+        store.delete(book.checksum).await.unwrap();
+
+        assert!(!book_path.exists());
+        assert_eq!(
+            tokio::fs::read(&outside_thumbnail).await.unwrap(),
+            b"keep outside cover"
+        );
+        assert!(thumbnail_link.symlink_metadata().is_ok());
+        assert!(matches!(
+            repository.retrieve_book(book.checksum).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+    }
+
     #[tokio::test]
     async fn primary_book_delete_failure_preserves_thumbnail_and_repository_row() {
         let layout = TestLayout::new("primary-delete-failure");
@@ -489,6 +695,33 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(tokio::fs::read(&victim_book).await.unwrap(), b"keep book");
+        assert!(repository.retrieve_book(book.checksum).await.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn delete_rejects_collection_symlink_that_escapes_book_root() {
+        use std::os::unix::fs::symlink;
+
+        let layout = TestLayout::new("delete-symlink-escape");
+        let outside = layout.base.join("outside-delete");
+        tokio::fs::create_dir(&outside).await.unwrap();
+        let victim_book = outside.join("victim.epub");
+        tokio::fs::write(&victim_book, b"keep external book")
+            .await
+            .unwrap();
+        symlink(&outside, layout.book_root.join("Fiction")).unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let book = sample_book(31, "Fiction", "victim.epub");
+        repository.save_book(&book).await.unwrap();
+
+        let result = store.delete(book.checksum).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            tokio::fs::read(&victim_book).await.unwrap(),
+            b"keep external book"
+        );
         assert!(repository.retrieve_book(book.checksum).await.is_ok());
     }
 

--- a/src/services/book_store.rs
+++ b/src/services/book_store.rs
@@ -70,15 +70,16 @@ impl BookStore {
         full_path: &Path,
         suggested_collection: Option<String>,
     ) -> Result<PathBuf> {
+        let source_path = full_path.to_str().ok_or_else(|| {
+            anyhow::anyhow!("book source path is not valid UTF-8: {}", full_path.display())
+        })?;
+        ensure_regular_file(full_path, "book source").await?;
         let collection = match suggested_collection {
             Some(collection) => title_case(&collection),
             None => self.collection_from_source(full_path)?,
         };
         let collection = safe_relative_collection(&collection)?;
         let destination_directory = self.book_root.join(collection);
-        let source_path = full_path.to_str().ok_or_else(|| {
-            anyhow::anyhow!("book source path is not valid UTF-8: {}", full_path.display())
-        })?;
         let destination = destination_directory.join(full_path.file_name().ok_or_else(|| {
             anyhow::anyhow!("book path has no file name: {}", full_path.display())
         })?);
@@ -137,39 +138,39 @@ impl BookStore {
         let file_name = safe_file_name(&book.file_name, "book file")?;
 
         let book_path = self.book_root.join(collection).join(file_name);
-        let book_path_string = book_path.to_str().ok_or_else(|| {
-            anyhow::anyhow!("book file path is not valid UTF-8: {}", book_path.display())
-        })?;
         ensure_path_within_root(&book_path, &self.book_root, "book file").await?;
-        self.store.delete(book_path_string).await?;
+        ensure_regular_file(&book_path, "book file").await?;
+        let staged_book_path = staging_path(&book_path, "book-delete")?;
+        rename_file(&self.store, &book_path, &staged_book_path).await?;
 
+        let mut staged_thumbnail = None;
         if !is_default_book_thumbnail(&book.thumbnail) {
             let unvalidated_path = self.thumbnail_root.join(&book.thumbnail);
             match safe_file_name(&book.thumbnail, "book thumbnail") {
                 Ok(thumbnail) => {
                     let thumbnail_path = self.thumbnail_root.join(thumbnail);
-                    let cleanup_result = async {
+                    let staging_result = async {
                         ensure_path_within_root(
                             &thumbnail_path,
                             &self.thumbnail_root,
                             "book thumbnail",
                         )
                         .await?;
-                        let thumbnail_path_string = thumbnail_path.to_str().ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "book thumbnail path is not valid UTF-8: {}",
-                                thumbnail_path.display()
-                            )
-                        })?;
-                        self.thumbnail_store.delete(thumbnail_path_string).await
+                        ensure_regular_file(&thumbnail_path, "book thumbnail").await?;
+                        let staged_path = staging_path(&thumbnail_path, "book-thumbnail-delete")?;
+                        rename_file(&self.thumbnail_store, &thumbnail_path, &staged_path).await?;
+                        Result::<PathBuf>::Ok(staged_path)
                     }
                     .await;
-                    if let Err(error) = cleanup_result {
-                        tracing::warn!(
-                            "Failed to delete book thumbnail {}: {}",
-                            thumbnail_path.display(),
-                            error
-                        );
+                    match staging_result {
+                        Ok(staged_path) => staged_thumbnail = Some((thumbnail_path, staged_path)),
+                        Err(error) => {
+                            tracing::warn!(
+                                "Failed to stage book thumbnail {} for deletion: {}",
+                                thumbnail_path.display(),
+                                error
+                            );
+                        }
                     }
                 }
                 Err(error) => {
@@ -182,9 +183,101 @@ impl BookStore {
             }
         }
 
-        self.repo.delete_book(checksum).await?;
+        if let Err(delete_error) = self.repo.delete_book(checksum).await {
+            let thumbnail_restore_error =
+                if let Some((thumbnail_path, staged_path)) = staged_thumbnail.as_ref() {
+                    restore_file(&self.thumbnail_store, staged_path, thumbnail_path)
+                        .await
+                        .err()
+                } else {
+                    None
+                };
+            let book_restore_error = restore_file(&self.store, &staged_book_path, &book_path)
+                .await
+                .err();
+
+            return match (book_restore_error, thumbnail_restore_error) {
+                (None, None) => Err(delete_error.into()),
+                (book_restore_error, thumbnail_restore_error) => Err(anyhow::anyhow!(
+                    "database deletion failed: {delete_error}; book restore error: {}; thumbnail restore error: {}",
+                    book_restore_error
+                        .map(|error| error.to_string())
+                        .unwrap_or_else(|| "none".to_string()),
+                    thumbnail_restore_error
+                        .map(|error| error.to_string())
+                        .unwrap_or_else(|| "none".to_string())
+                )),
+            };
+        }
+
+        delete_file(&self.store, &staged_book_path).await?;
+        if let Some((_, staged_path)) = staged_thumbnail {
+            if let Err(error) = delete_file(&self.thumbnail_store, &staged_path).await {
+                tracing::warn!(
+                    "Failed to delete staged book thumbnail {}: {}",
+                    staged_path.display(),
+                    error
+                );
+            }
+        }
         Ok(())
     }
+}
+
+fn staging_path(path: &Path, label: &str) -> Result<PathBuf> {
+    let parent = path.parent().ok_or_else(|| {
+        anyhow::anyhow!("file path has no parent for staging: {}", path.display())
+    })?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            anyhow::anyhow!("file name is not valid UTF-8 for staging: {}", path.display())
+        })?;
+    Ok(parent.join(format!(".{file_name}.{label}-{:032x}", rand::random::<u128>())))
+}
+
+async fn rename_file(store: &FileStorer, source: &Path, destination: &Path) -> Result<()> {
+    let source = source
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("source path is not valid UTF-8: {}", source.display()))?;
+    let destination = destination.to_str().ok_or_else(|| {
+        anyhow::anyhow!("destination path is not valid UTF-8: {}", destination.display())
+    })?;
+    store.rename(source, destination).await
+}
+
+async fn delete_file(store: &FileStorer, path: &Path) -> Result<()> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("file path is not valid UTF-8: {}", path.display()))?;
+    store.delete(path).await
+}
+
+async fn restore_file(store: &FileStorer, staged_path: &Path, original_path: &Path) -> Result<()> {
+    let staged_path = staged_path.to_str().ok_or_else(|| {
+        anyhow::anyhow!("staged path is not valid UTF-8: {}", staged_path.display())
+    })?;
+    let original_path = original_path.to_str().ok_or_else(|| {
+        anyhow::anyhow!(
+            "original path is not valid UTF-8: {}",
+            original_path.display()
+        )
+    })?;
+    store.restore(staged_path, original_path).await
+}
+
+async fn ensure_regular_file(path: &Path, description: &str) -> Result<()> {
+    let metadata = tokio::fs::symlink_metadata(path).await.map_err(|error| {
+        anyhow::anyhow!("failed to inspect {description} ({}): {error}", path.display())
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(anyhow::anyhow!(
+            "{description} must be a regular file and not a symlink: {}",
+            path.display()
+        ));
+    }
+    Ok(())
 }
 
 fn absolute_path(path: &Path, description: &str) -> Result<PathBuf> {
@@ -549,6 +642,26 @@ mod tests {
         assert!(!outside.join("Dune.epub").exists());
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn add_file_rejects_symlink_source() {
+        use std::os::unix::fs::symlink;
+
+        let layout = TestLayout::new("add-symlink-source");
+        let target = layout.source_root.join("target.epub");
+        tokio::fs::write(&target, b"book").await.unwrap();
+        let source = layout.source_root.join("Dune.epub");
+        symlink(&target, &source).unwrap();
+        let (store, _) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+
+        let result = store.add_file(&source, Some("Fiction".to_string())).await;
+
+        assert!(result.is_err());
+        assert!(source.symlink_metadata().is_ok());
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"book");
+        assert!(!layout.book_root.join("Fiction/Dune.epub").exists());
+    }
+
     #[tokio::test]
     async fn delete_removes_book_generated_thumbnail_and_repository_row() {
         let layout = TestLayout::new("delete-generated-thumbnail");
@@ -683,6 +796,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn repository_delete_failure_restores_book_and_thumbnail() {
+        let layout = TestLayout::new("repository-delete-failure");
+        let book_path = layout.book_root.join("Fiction/Dune.epub");
+        tokio::fs::create_dir_all(book_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&book_path, b"book").await.unwrap();
+        let thumbnail_path = layout.thumbnail_root.join("dune-cover.jpg");
+        tokio::fs::write(&thumbnail_path, b"cover").await.unwrap();
+
+        let database_url = format!("sqlite://{}", layout.base.join("books.sqlite").display());
+        let repository: Repository = Arc::new(
+            SqlRepository::new(&database_url, None)
+                .await
+                .expect("repository should initialize"),
+        );
+        let book_files: FileStorer = Arc::new(FileSystemStore::new(
+            layout
+                .book_root
+                .to_str()
+                .expect("book root should be UTF-8"),
+        ));
+        let thumbnail_files: FileStorer = Arc::new(FileSystemStore::new(
+            layout
+                .thumbnail_root
+                .to_str()
+                .expect("thumbnail root should be UTF-8"),
+        ));
+        let store = BookStore::new_with_roots(
+            book_files,
+            thumbnail_files,
+            repository.clone(),
+            &layout.book_root,
+            &layout.thumbnail_root,
+        );
+        let mut book = sample_book(16, "Fiction", "Dune.epub");
+        book.thumbnail = "dune-cover.jpg".to_string();
+        repository.save_book(&book).await.unwrap();
+
+        let pool = sqlx::SqlitePool::connect(&database_url).await.unwrap();
+        sqlx::query(
+            "CREATE TRIGGER fail_book_delete BEFORE DELETE ON books \
+             BEGIN SELECT RAISE(FAIL, 'forced delete failure'); END",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = store.delete(book.checksum).await;
+
+        assert!(result.is_err());
+        assert_eq!(tokio::fs::read(&book_path).await.unwrap(), b"book");
+        assert_eq!(tokio::fs::read(&thumbnail_path).await.unwrap(), b"cover");
+        assert!(repository.retrieve_book(book.checksum).await.is_ok());
+    }
+
+    #[tokio::test]
     async fn delete_rejects_malformed_book_identity_without_deleting_in_root_alias() {
         let layout = TestLayout::new("delete-book-alias");
         let victim_book = layout.book_root.join("victim.epub");
@@ -722,6 +892,27 @@ mod tests {
             tokio::fs::read(&victim_book).await.unwrap(),
             b"keep external book"
         );
+        assert!(repository.retrieve_book(book.checksum).await.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn delete_rejects_dangling_book_symlink_and_preserves_row() {
+        use std::os::unix::fs::symlink;
+
+        let layout = TestLayout::new("delete-dangling-book-symlink");
+        let collection = layout.book_root.join("Fiction");
+        tokio::fs::create_dir(&collection).await.unwrap();
+        let book_link = collection.join("Dune.epub");
+        symlink(layout.base.join("missing.epub"), &book_link).unwrap();
+        let (store, repository) = store_for_roots(&layout.book_root, &layout.thumbnail_root).await;
+        let book = sample_book(33, "Fiction", "Dune.epub");
+        repository.save_book(&book).await.unwrap();
+
+        let result = store.delete(book.checksum).await;
+
+        assert!(result.is_err());
+        assert!(book_link.symlink_metadata().is_ok());
         assert!(repository.retrieve_book(book.checksum).await.is_ok());
     }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,20 +1,22 @@
+mod book_store;
 mod chatgpt;
 mod logging;
 mod media_store;
 mod monitor;
 mod pirate_bay;
 mod search;
+mod sharing;
 mod task_manager;
 mod video_information;
 mod youtube;
-mod sharing;
 
-pub use logging::{TVSERVER_LOG, DBTOOL_LOG, TAURI_LOG, setup_logging};
+pub use book_store::BookStore;
+pub use logging::{setup_logging, DBTOOL_LOG, TAURI_LOG, TVSERVER_LOG};
 pub use media_store::MediaStore;
 pub use monitor::Monitor;
 pub use pirate_bay::{PirateClient, PirateFetcher};
 pub use search::{SearchEngine, SearchEngineMap, SearchService};
+pub use sharing::SharingService;
 pub use task_manager::TaskManager;
 pub use video_information::MetaDataManager;
 pub use youtube::{YoutubeClient, YoutubeFetcher, YoutubeResult};
-pub use sharing::SharingService;

--- a/tests/common/context.rs
+++ b/tests/common/context.rs
@@ -1,23 +1,28 @@
-use app_lib::domain::traits::{Checker, Repository, Storer};
-use app_lib::domain::messagebus::{LocalMessageExchange, MessageExchange, MessageFilter};
-use app_lib::entrypoints::Context;
-use app_lib::services::{SearchService, TaskManager};
-use std::sync::Arc;
 use anyhow::Result;
+use app_lib::adaptors::FileSystemStore;
+use app_lib::domain::messagebus::{LocalMessageExchange, MessageExchange, MessageFilter};
+use app_lib::domain::traits::{Checker, FileStorer, Repository, Storer};
+use app_lib::entrypoints::Context;
+use app_lib::services::{BookStore, SearchService, TaskManager};
+use std::sync::Arc;
 
 pub async fn get_context(
-    store: Storer, 
-    searcher: SearchService, 
-    task_manager: Arc<TaskManager>, 
-    repository: Repository, 
-    checker: Checker) -> Result<Context> 
-{
+    store: Storer,
+    searcher: SearchService,
+    task_manager: Arc<TaskManager>,
+    repository: Repository,
+    checker: Checker,
+) -> Result<Context> {
     let local_message_exchange = LocalMessageExchange::new();
-    
+
     let messenger = MessageExchange::new(
-        local_message_exchange.new_sender(), 
-        local_message_exchange.listen_for_messages( MessageFilter::All).await?
+        local_message_exchange.new_sender(),
+        local_message_exchange
+            .listen_for_messages(MessageFilter::All)
+            .await?,
     );
+
+    let (book_store, book_file_storer) = get_book_services(repository.clone());
 
     Ok(Context::new(
         store,
@@ -27,7 +32,32 @@ pub async fn get_context(
         repository,
         checker,
         local_message_exchange,
+        book_store,
+        book_file_storer,
         None,
     ))
 }
 
+pub fn get_book_services(repository: Repository) -> (Arc<BookStore>, FileStorer) {
+    let test_root =
+        std::env::temp_dir().join(format!("tvserver-context-tests-{}", std::process::id()));
+    let book_root = test_root.join("books");
+    let thumbnail_root = test_root.join("book-thumbnails");
+    let book_file_storer: FileStorer = Arc::new(FileSystemStore::new(
+        book_root.to_str().expect("book test root should be UTF-8"),
+    ));
+    let thumbnail_file_storer: FileStorer = Arc::new(FileSystemStore::new(
+        thumbnail_root
+            .to_str()
+            .expect("book thumbnail test root should be UTF-8"),
+    ));
+    let book_store = Arc::new(BookStore::new_with_roots(
+        book_file_storer.clone(),
+        thumbnail_file_storer,
+        repository,
+        &book_root,
+        &thumbnail_root,
+    ));
+
+    (book_store, book_file_storer)
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
+mod context;
 mod json_fetcher;
+mod media_checker;
 mod media_store;
 mod player;
 mod repository;
@@ -10,10 +12,11 @@ mod spawner;
 mod task_manager;
 mod text_fetcher;
 mod torrents;
-mod media_checker;
-mod context;
 
+#[allow(unused_imports)]
+pub use context::{get_book_services, get_context};
 pub use json_fetcher::get_json_fetcher;
+pub use media_checker::get_checker;
 #[allow(unused_imports)]
 pub use media_store::get_media_store;
 #[allow(unused_imports)]
@@ -27,6 +30,3 @@ pub use spawner::{get_no_spawner, get_spawner};
 pub use task_manager::get_task_manager;
 pub use text_fetcher::get_text_fetcher;
 pub use torrents::get_torrent_downloader;
-pub use media_checker::get_checker;
-#[allow(unused_imports)]
-pub use context::get_context;

--- a/tests/play_test.rs
+++ b/tests/play_test.rs
@@ -1,17 +1,15 @@
 mod common;
 
-use crate::common::{
-    get_media_store, get_pirate_search, get_repository, get_task_manager,
-};
+use crate::common::{get_media_store, get_pirate_search, get_repository, get_task_manager};
 use anyhow::Result;
-use common::get_checker;
 use app_lib::domain::config::MOVIE_DIR;
+use app_lib::domain::messagebus::{LocalMessageExchange, MessageExchange, MessageFilter};
 use app_lib::domain::messages::PlayRequest;
+use app_lib::{domain::messages::Response, entrypoints};
+use common::get_checker;
 use std::env;
 use std::net::SocketAddr;
 use std::str::FromStr;
-use app_lib::domain::messagebus::{LocalMessageExchange, MessageExchange, MessageFilter};
-use app_lib::{domain::messages::Response, entrypoints};
 
 #[tokio::test]
 async fn test_remote_play() -> Result<()> {
@@ -20,23 +18,31 @@ async fn test_remote_play() -> Result<()> {
     let local_exchange = LocalMessageExchange::new();
     let exchange = MessageExchange::new(
         local_exchange.new_sender(),
-        local_exchange.listen_for_messages(MessageFilter::All).await?
+        local_exchange
+            .listen_for_messages(MessageFilter::All)
+            .await?,
     );
 
     let key = SocketAddr::from_str("0.0.0.0:456").unwrap();
 
-    exchange.add_player(key.to_string(), common::get_remote_player()).await;
+    exchange
+        .add_player(key.to_string(), common::get_remote_player())
+        .await;
 
     let searcher = get_pirate_search("torrents_get.json", "pb_search.html").await;
 
+    let repository = get_repository().await;
+    let (book_store, book_file_storer) = common::get_book_services(repository.clone());
     let context = entrypoints::Context::new(
         get_media_store(),
         searcher,
         exchange,
         get_task_manager(),
-        get_repository().await,
+        repository,
         get_checker(),
         local_exchange,
+        book_store,
+        book_file_storer,
         None,
     );
 
@@ -44,7 +50,7 @@ async fn test_remote_play() -> Result<()> {
 
     let client = reqwest::Client::new();
 
-    let request = PlayRequest{
+    let request = PlayRequest {
         collection: "".to_string(),
         video: "test.mp4".to_string(),
         remote_address: None,


### PR DESCRIPTION
## Summary

- add a repository-backed `BookStore` for listing book collections and moving downloads into `BOOK_DIR`
- delete book files and generated thumbnails while preserving `default-book.jpg` and keeping thumbnail cleanup non-fatal
- enforce capability-rooted filesystem containment for create, move, EXDEV copy, quarantine, restore, and delete operations
- reject source and stored book symlinks/non-regular files, including dangling symlinks
- restore quarantined book and thumbnail files if repository deletion fails without overwriting concurrent replacements
- expose `BookStore` and the underlying `BOOK_DIR` file store through runtime and test `Context`

## Impact

This completes Task 5 of the ebook support plan and provides the storage/context boundary required by later ingestion, API, and Tauri tasks without changing existing video behavior.

## Validation

- `make test` — 152 unit tests passed, 4 ignored; all 7 integration tests passed
- `make webserver`
- `cargo clippy --no-default-features --features webserver --lib --tests -- -A dead_code`
- `git diff --check`
- independent security re-review: no Critical or Important findings

Closes #40
