### PR TITLE
Add Tauri book commands

### DIFF
--- a/src/domain/algorithm/naming.rs
+++ b/src/domain/algorithm/naming.rs
@@ -1,8 +1,6 @@
 #[cfg(not(feature = "webserver"))]
 use crate::domain::config::get_book_thumbnail_dir;
 #[cfg(not(feature = "webserver"))]
-use crate::domain::config::{get_book_dir, get_book_thumbnail_dir};
-#[cfg(not(feature = "webserver"))]
 use crate::domain::config::get_thumbnail_dir;
 use crate::domain::config::{get_book_dir, get_movie_dir};
 use mockall::lazy_static;

--- a/src/entrypoints/tauri_api.rs
+++ b/src/entrypoints/tauri_api.rs
@@ -14,9 +14,11 @@ use crate::domain::models::{
     TaskListResults, AVAILABLE_CONVERSIONS,
 };
 #[cfg(not(feature = "webserver"))]
-use crate::domain::traits::MediaSharer;
+use crate::domain::traits::{MediaSharer, Repository};
 #[cfg(not(feature = "webserver"))]
 use crate::domain::{SearchEngineType, TaskType};
+#[cfg(not(feature = "webserver"))]
+use crate::services::BookStore;
 #[cfg(not(feature = "webserver"))]
 use super::context::Context;
 
@@ -122,7 +124,8 @@ async fn list_media(state: &SharedState, collection: &str) -> Result<MediaItem, 
 pub async fn list_root_books(
     state: tauri::State<'_, SharedState>,
 ) -> Result<BookCollectionDetails, String> {
-    list_book_collection(&state, "").await
+    let book_store = state.get_book_store();
+    list_books_core(book_store.as_ref(), "").await
 }
 
 #[cfg(not(feature = "webserver"))]
@@ -131,16 +134,16 @@ pub async fn list_books(
     state: tauri::State<'_, SharedState>,
     collection: String,
 ) -> Result<BookCollectionDetails, String> {
-    list_book_collection(&state, &collection).await
+    let book_store = state.get_book_store();
+    list_books_core(book_store.as_ref(), &collection).await
 }
 
 #[cfg(not(feature = "webserver"))]
-async fn list_book_collection(
-    state: &SharedState,
+async fn list_books_core(
+    book_store: &BookStore,
     collection: &str,
 ) -> Result<BookCollectionDetails, String> {
-    state
-        .get_book_store()
+    book_store
         .list(collection)
         .await
         .map_err(|error| error.to_string())
@@ -159,9 +162,17 @@ pub async fn get_book(
     state: tauri::State<'_, SharedState>,
     checksum: String,
 ) -> Result<BookDetails, String> {
-    let checksum = parse_book_checksum(&checksum)?;
-    state
-        .get_repository()
+    let repository = state.get_repository();
+    get_book_core(&repository, &checksum).await
+}
+
+#[cfg(not(feature = "webserver"))]
+async fn get_book_core(
+    repository: &Repository,
+    checksum: &str,
+) -> Result<BookDetails, String> {
+    let checksum = parse_book_checksum(checksum)?;
+    repository
         .retrieve_book(checksum)
         .await
         .map_err(|error| error.to_string())
@@ -173,9 +184,14 @@ pub async fn delete_book(
     state: tauri::State<'_, SharedState>,
     checksum: String,
 ) -> Result<Response, String> {
-    let checksum = parse_book_checksum(&checksum)?;
-    state
-        .get_book_store()
+    let book_store = state.get_book_store();
+    delete_book_core(book_store.as_ref(), &checksum).await
+}
+
+#[cfg(not(feature = "webserver"))]
+async fn delete_book_core(book_store: &BookStore, checksum: &str) -> Result<Response, String> {
+    let checksum = parse_book_checksum(checksum)?;
+    book_store
         .delete(checksum)
         .await
         .map(|()| Response::success("success".to_string()))
@@ -342,20 +358,172 @@ pub fn register_commands() -> impl Fn(Invoke) -> bool + Send + Sync + 'static {
 
 #[cfg(all(test, not(feature = "webserver")))]
 mod tests {
-    use super::{delete_book, get_book, list_books, list_root_books, parse_book_checksum};
+    use std::{path::PathBuf, sync::Arc};
 
-    #[test]
-    fn rejects_malformed_book_checksum() {
-        let error = parse_book_checksum("not-a-checksum").unwrap_err();
+    use crate::{
+        adaptors::{FileSystemStore, SqlRepository},
+        domain::{
+            models::{BookDetails, DEFAULT_BOOK_THUMBNAIL},
+            traits::{FileStorer, Repository},
+        },
+        services::BookStore,
+    };
 
-        assert!(error.starts_with("Invalid book checksum 'not-a-checksum':"));
+    use super::{delete_book_core, get_book_core, list_books_core};
+
+    fn sample_book(checksum: i64, collection: &str, file_name: &str) -> BookDetails {
+        BookDetails {
+            checksum,
+            collection: collection.to_string(),
+            file_name: file_name.to_string(),
+            title: file_name.to_string(),
+            thumbnail: DEFAULT_BOOK_THUMBNAIL.to_string(),
+            ..BookDetails::default()
+        }
     }
 
-    #[test]
-    fn exposes_book_command_handlers() {
-        let _ = list_root_books;
-        let _ = list_books;
-        let _ = get_book;
-        let _ = delete_book;
+    async fn test_book_store() -> (Arc<BookStore>, Repository, PathBuf) {
+        let test_root = std::env::temp_dir().join(format!(
+            "tvserver-tauri-book-commands-{:032x}",
+            rand::random::<u128>()
+        ));
+        let book_root = test_root.join("books");
+        let thumbnail_root = test_root.join("book-thumbnails");
+        tokio::fs::create_dir_all(&book_root).await.unwrap();
+        tokio::fs::create_dir_all(&thumbnail_root).await.unwrap();
+
+        let repository: Repository =
+            Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let book_files: FileStorer = Arc::new(FileSystemStore::new(
+            book_root.to_str().expect("book test root should be UTF-8"),
+        ));
+        let thumbnail_files: FileStorer = Arc::new(FileSystemStore::new(
+            thumbnail_root
+                .to_str()
+                .expect("thumbnail test root should be UTF-8"),
+        ));
+        let store = Arc::new(BookStore::new_with_roots(
+            book_files,
+            thumbnail_files,
+            repository.clone(),
+            &book_root,
+            &thumbnail_root,
+        ));
+
+        (store, repository, test_root)
+    }
+
+    #[tokio::test]
+    async fn lists_root_books_through_book_store() {
+        let (store, repository, test_root) = test_book_store().await;
+        repository
+            .save_book(&sample_book(1, "", "root.epub"))
+            .await
+            .unwrap();
+        repository
+            .save_book(&sample_book(2, "Shelf", "nested.epub"))
+            .await
+            .unwrap();
+
+        let result = list_books_core(store.as_ref(), "").await.unwrap();
+
+        assert_eq!(result.collection, "");
+        assert_eq!(result.books.len(), 1);
+        assert_eq!(result.books[0].checksum, 1);
+        drop(store);
+        tokio::fs::remove_dir_all(test_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn lists_requested_collection_through_book_store() {
+        let (store, repository, test_root) = test_book_store().await;
+        repository
+            .save_book(&sample_book(3, "Shelf", "on-shelf.epub"))
+            .await
+            .unwrap();
+        repository
+            .save_book(&sample_book(4, "Other", "elsewhere.epub"))
+            .await
+            .unwrap();
+
+        let result = list_books_core(store.as_ref(), "Shelf").await.unwrap();
+
+        assert_eq!(result.collection, "Shelf");
+        assert_eq!(result.books.len(), 1);
+        assert_eq!(result.books[0].checksum, 3);
+        drop(store);
+        tokio::fs::remove_dir_all(test_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn retrieves_book_for_full_width_i64_checksum() {
+        let (store, repository, test_root) = test_book_store().await;
+        let book = sample_book(i64::MAX, "Shelf", "largest.epub");
+        repository.save_book(&book).await.unwrap();
+
+        let result = get_book_core(&repository, &i64::MAX.to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(result.checksum, i64::MAX);
+        assert_eq!(result.file_name, "largest.epub");
+        drop(store);
+        tokio::fs::remove_dir_all(test_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn deletes_book_through_book_store_and_returns_success() {
+        let (store, repository, test_root) = test_book_store().await;
+        let book = sample_book(42, "Shelf", "delete-me.epub");
+        repository.save_book(&book).await.unwrap();
+        let book_path = test_root.join("books/Shelf/delete-me.epub");
+        tokio::fs::create_dir_all(book_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&book_path, b"book").await.unwrap();
+
+        let response = delete_book_core(store.as_ref(), "42").await.unwrap();
+
+        assert_eq!(response.message, "success");
+        assert!(response.errors.is_empty());
+        assert_eq!(
+            serde_json::to_value(&response).unwrap()["message"],
+            "success"
+        );
+        assert!(repository.retrieve_book(42).await.is_err());
+        assert!(tokio::fs::metadata(&book_path).await.is_err());
+        drop(store);
+        tokio::fs::remove_dir_all(test_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn command_cores_reject_malformed_book_checksum() {
+        let (store, repository, test_root) = test_book_store().await;
+
+        let get_error = get_book_core(&repository, "not-a-checksum")
+            .await
+            .unwrap_err();
+        let delete_error = delete_book_core(store.as_ref(), "not-a-checksum")
+            .await
+            .unwrap_err();
+
+        assert!(get_error.starts_with("Invalid book checksum 'not-a-checksum':"));
+        assert_eq!(delete_error, get_error);
+        drop(store);
+        tokio::fs::remove_dir_all(test_root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn command_cores_map_backend_errors_to_strings() {
+        let (store, repository, test_root) = test_book_store().await;
+        let expected = sqlx::Error::RowNotFound.to_string();
+
+        let get_error = get_book_core(&repository, "404").await.unwrap_err();
+        let delete_error = delete_book_core(store.as_ref(), "404").await.unwrap_err();
+
+        assert_eq!(get_error, expected);
+        assert_eq!(delete_error, expected);
+        drop(store);
+        tokio::fs::remove_dir_all(test_root).await.unwrap();
     }
 }

--- a/src/entrypoints/tauri_api.rs
+++ b/src/entrypoints/tauri_api.rs
@@ -9,7 +9,10 @@ use crate::domain::messages::{
     ClientLogMessage, Command, ConversionRequest, CopyFromServerRequest, DownloadRequest, MediaItem, PlayRequest, PlayerList, Response
 };
 #[cfg(not(feature = "webserver"))]
-use crate::domain::models::{Conversion, DownloadableItem, SearchResults, TaskListResults, AVAILABLE_CONVERSIONS};
+use crate::domain::models::{
+    BookCollectionDetails, BookDetails, Conversion, DownloadableItem, SearchResults,
+    TaskListResults, AVAILABLE_CONVERSIONS,
+};
 #[cfg(not(feature = "webserver"))]
 use crate::domain::traits::MediaSharer;
 #[cfg(not(feature = "webserver"))]
@@ -112,6 +115,71 @@ async fn list_media(state: &SharedState, collection: &str) -> Result<MediaItem, 
         Ok(result) => Ok(result),
         Err(e) => Err(e.to_string()),
     }
+}
+
+#[cfg(not(feature = "webserver"))]
+#[tauri::command]
+pub async fn list_root_books(
+    state: tauri::State<'_, SharedState>,
+) -> Result<BookCollectionDetails, String> {
+    list_book_collection(&state, "").await
+}
+
+#[cfg(not(feature = "webserver"))]
+#[tauri::command]
+pub async fn list_books(
+    state: tauri::State<'_, SharedState>,
+    collection: String,
+) -> Result<BookCollectionDetails, String> {
+    list_book_collection(&state, &collection).await
+}
+
+#[cfg(not(feature = "webserver"))]
+async fn list_book_collection(
+    state: &SharedState,
+    collection: &str,
+) -> Result<BookCollectionDetails, String> {
+    state
+        .get_book_store()
+        .list(collection)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(not(feature = "webserver"))]
+fn parse_book_checksum(checksum: &str) -> Result<i64, String> {
+    checksum
+        .parse::<i64>()
+        .map_err(|error| format!("Invalid book checksum '{checksum}': {error}"))
+}
+
+#[cfg(not(feature = "webserver"))]
+#[tauri::command]
+pub async fn get_book(
+    state: tauri::State<'_, SharedState>,
+    checksum: String,
+) -> Result<BookDetails, String> {
+    let checksum = parse_book_checksum(&checksum)?;
+    state
+        .get_repository()
+        .retrieve_book(checksum)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(not(feature = "webserver"))]
+#[tauri::command]
+pub async fn delete_book(
+    state: tauri::State<'_, SharedState>,
+    checksum: String,
+) -> Result<Response, String> {
+    let checksum = parse_book_checksum(&checksum)?;
+    state
+        .get_book_store()
+        .delete(checksum)
+        .await
+        .map(|()| Response::success("success".to_string()))
+        .map_err(|error| error.to_string())
 }
 
 #[cfg(not(feature = "webserver"))]
@@ -255,6 +323,10 @@ pub fn register_commands() -> impl Fn(Invoke) -> bool + Send + Sync + 'static {
         youtube_search,
         list_root_collection,
         list_collection,
+        list_root_books,
+        list_books,
+        get_book,
+        delete_book,
         log_client_message,
         remote_play,
         remote_command,
@@ -266,4 +338,24 @@ pub fn register_commands() -> impl Fn(Invoke) -> bool + Send + Sync + 'static {
         channel_connect,
         download_videos
     ]
+}
+
+#[cfg(all(test, not(feature = "webserver")))]
+mod tests {
+    use super::{delete_book, get_book, list_books, list_root_books, parse_book_checksum};
+
+    #[test]
+    fn rejects_malformed_book_checksum() {
+        let error = parse_book_checksum("not-a-checksum").unwrap_err();
+
+        assert!(error.starts_with("Invalid book checksum 'not-a-checksum':"));
+    }
+
+    #[test]
+    fn exposes_book_command_handlers() {
+        let _ = list_root_books;
+        let _ = list_books;
+        let _ = get_book;
+        let _ = delete_book;
+    }
 }


### PR DESCRIPTION
## Summary

- add Tauri commands to list root books, list a book collection, retrieve a book, and delete a book
- keep the command surface behind the non-webserver feature gate and register all four handlers
- parse checksum strings through a shared validated boundary and preserve BookStore deletion safeguards
- add real repository and filesystem-backed command-core tests
- remove duplicate non-webserver imports that prevented the default Tauri build from compiling

## Context

This is Task 12 in the current ebook support plan. Issue #46 uses the earlier Task 11 numbering from before the OpenAPI task was inserted.

## Validation

- `cargo test entrypoints::tauri_api::tests --lib` — 6 passed
- `cargo test --lib` — 147 passed, 4 ignored
- `cargo test --no-default-features --features webserver` — 156 library tests passed, 4 ignored; all integration and doc tests passed
- `cargo check`
- `cargo check --no-default-features --features webserver`
- `git diff --check d680d6f..HEAD`

The checks retain one pre-existing dead-code warning for `DEFAULT_MIGRATIONS_DIR`.

Closes #46