### PR TITLE
Document ebook runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 TV Server 
 - provides ad free viewing of videos published on the public internet.
 - connects Youtube to your TV and lets you control them with your mobile phone.
+- manages a local library of PDF and EPUB books alongside the video library.
 - is a thin wrapper around [FFmpeg](https://ffmpeg.org/), 
 [yt-dlp](https://github.com/yt-dlp/yt-dlp) and [Transmission](https://transmissionbt.com/)
 
@@ -13,7 +14,7 @@ Architecturally, it consists of 3 components:
 - The remote control, which is a web app that acts as a remote control
 - The player, which is a web app that runs on the TV
 - The server, which is a daemon that hosts the player and remote control apps and handles downloading 
-and streaming movies; 
+and serving videos and books;
 
 ![Overview](docs/images/overview.svg)
 
@@ -41,17 +42,44 @@ NB YouTube search will not work until a key for the Google API is provided throu
 
 The tvserver daemon is configured through the following environment variables
 
-| Environment Variable | Description                                                                        |
-|----------------------|------------------------------------------------------------------------------------|
-| GOOGLE_KEY           | *A key to use with the Google API, see below for instructions for obtaining a key. |
-| MOVIE_DIR            | *The directory where movies will be stored.                                        |
-| CLIENT_DIR           | The directory contain the client apps, defaults to `clients`                       |
-| TRANSMISSION_URL     | URL to access the Transmission HTTP interface                                      |
-| TRANSMISSION_USER    | Username to access the Transmission HTTP interface                                 |
-| TRANSMISSION_PWD     | Password to access the Transmission HTTP interface                                 |
-| TORRENT_DIR          | The directory where torrent files are saved.                                       |
+| Environment Variable | Description                                                                                   |
+|----------------------|-----------------------------------------------------------------------------------------------|
+| GOOGLE_KEY           | *A key to use with the Google API, see below for instructions for obtaining a key.            |
+| MOVIE_DIR            | *The directory where movies will be stored.                                                   |
+| BOOK_DIR             | *The directory where PDF and EPUB books will be stored.                                       |
+| BOOK_THUMBNAIL_DIR   | The directory for book covers; defaults to `<BOOK_DIR>/.thumbnails`.                           |
+| CLIENT_DIR           | The directory contain the client apps, defaults to `clients`                                  |
+| TRANSMISSION_URL     | URL to access the Transmission HTTP interface                                                 |
+| TRANSMISSION_USER    | Username to access the Transmission HTTP interface                                            |
+| TRANSMISSION_PWD     | Password to access the Transmission HTTP interface                                            |
+| TORRENT_DIR          | The directory where torrent files are saved.                                                  |
 
 `*` Required
+
+## Book Library
+
+PDF and EPUB books are stored separately from videos under `BOOK_DIR`. Book covers are written to
+`BOOK_THUMBNAIL_DIR`, which is optional and defaults to `<BOOK_DIR>/.thumbnails`. If a cover cannot
+be extracted, the bundled `assets/book/default-book.jpg` is materialized there as
+`default-book.jpg`. This shared fallback is preserved when books are deleted.
+
+PDF metadata extraction is Rust-native and does not require Pdfium. First-page PDF thumbnail
+rendering is optional, is disabled in default builds, and can be enabled with the Cargo feature
+`pdf-thumbnails`. When enabled, the renderer attempts to load a target-compatible Pdfium library
+from the current directory (for a packaged library) and then from the system. If Pdfium cannot be
+loaded or a page cannot be rendered, metadata extraction still succeeds and the book uses
+`default-book.jpg`.
+
+Default builds, including Android builds without `pdf-thumbnails`, do not require Pdfium or desktop
+command-line PDF tools. To use `pdf-thumbnails` on Android, package a Pdfium library that is
+compatible with the Android target.
+
+The canonical frontend REST contract location is `docs/api/openapi.yaml`.
+
+## Development
+
+All ebook-support implementation branches must be based on `spec/ebook-support`, not directly on
+`main`, so they inherit the approved specification and implementation plan.
 
 ## Obtaining a Google API Key
 
@@ -128,5 +156,3 @@ Clicking brings up a dialog asking to confirm before downloading.
 ### The final tab provides a list of running tasks, e.g. downloads and conversions in progress.
 
 <img src="docs/images/tasks.png" alt="Task List" width="585"/>
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - .:/opt/tvserver
       - ${HOME}/Movies:/Movies
+      - ${HOME}/Books:/Books
       - .transmission/config:/config
       - .transmission/downloads:/downloads
       - .transmission/watch:/watch

--- a/env.sample
+++ b/env.sample
@@ -3,9 +3,9 @@ CLIENT_DIR=/var/www/client
 DATABASE_URL=:memory:
 DATABASE_MIGRATION_DIR=./migrations
 MOVIE_DIR=/Movies
-BOOK_DIR=/Movies/Books
+BOOK_DIR=/Books
 # Optional; defaults to ${BOOK_DIR}/.thumbnails
-# BOOK_THUMBNAIL_DIR=/Movies/Books/.thumbnails
+# BOOK_THUMBNAIL_DIR=/Books/.thumbnails
 TRANSMISSION_USER=transmission
 TRANSMISSION_PWD=abcd1234
 TRANSMISSION_URL="http://transmission:9091/transmission/rpc"

--- a/env.sample
+++ b/env.sample
@@ -3,6 +3,9 @@ CLIENT_DIR=/var/www/client
 DATABASE_URL=:memory:
 DATABASE_MIGRATION_DIR=./migrations
 MOVIE_DIR=/Movies
+BOOK_DIR=/Movies/Books
+# Optional; defaults to ${BOOK_DIR}/.thumbnails
+# BOOK_THUMBNAIL_DIR=/Movies/Books/.thumbnails
 TRANSMISSION_USER=transmission
 TRANSMISSION_PWD=abcd1234
 TRANSMISSION_URL="http://transmission:9091/transmission/rpc"


### PR DESCRIPTION
## Summary

- document `BOOK_DIR`, optional `BOOK_THUMBNAIL_DIR`, and the stable default-cover behavior
- explain optional Pdfium-backed thumbnails, graceful fallback, and Android packaging constraints
- point frontend developers to `docs/api/openapi.yaml` and restate the `spec/ebook-support` branch requirement
- add disjoint, persistent `/Movies` and `/Books` sample paths to `env.sample` and Docker Compose

## Plan and issue context

Implements Task 13, **Documentation and Runtime Configuration**, from `docs/superpowers/plans/2026-07-13-ebook-support.md`.

Issue #48 predates the plan's insertion of a separate documentation task and still labels final verification as Task 13. This branch also ran the verification checks listed there.

Closes #48.

## Validation

- `cargo test --no-default-features --features webserver --lib book` — 87 passed
- `make test` — 156 library tests and 7 integration tests passed; 4 library tests ignored
- `cargo build` — default Tauri build passed
- `docker compose --env-file env.sample config` — resolved `Movies -> /Movies` and `Books -> /Books` persistent bind mounts
- `git diff --check origin/spec/ebook-support..HEAD` — passed
- `git merge-base --is-ancestor origin/spec/ebook-support HEAD` — passed
- focused and whole-branch agent reviews — no remaining findings

Known pre-existing warnings: the unused `DEFAULT_MIGRATIONS_DIR` constant during Rust builds, unset `UID` during local Compose rendering, and Compose's obsolete top-level `version` notice.