### PR TITLE
Ebook support Task 9: Book idle scanner

### DIFF
--- a/src/adaptors/object_store.rs
+++ b/src/adaptors/object_store.rs
@@ -1025,6 +1025,11 @@ impl Filer for FileStoreObject {
     }
 }
 
+fn directory_entry_name(name: OsString) -> Result<String> {
+    name.into_string()
+        .map_err(|name| anyhow!("directory entry name is not valid UTF-8: {name:?}"))
+}
+
 #[async_trait]
 impl FileStore for FileSystemStore {
     async fn create_folder(&self, path: &Path) -> Result<()> {
@@ -1049,16 +1054,13 @@ impl FileStore for FileSystemStore {
         }
 
         let mut read_dir = fs::read_dir(path).await?;
-        while let Ok(Some(entry)) = read_dir.next_entry().await {
-            if let Ok(name) = entry.file_name().into_string() {
-                if entry.path().is_dir() {
-                    /*if !_path.is_empty() {
-                        name = format!("{}/{}", _path, name);
-                    }*/
-                    directories.push(name);
-                } else {
-                    files.push(name);
-                }
+        while let Some(entry) = read_dir.next_entry().await? {
+            let name = directory_entry_name(entry.file_name())?;
+            let file_type = entry.file_type().await?;
+            if file_type.is_dir() {
+                directories.push(name);
+            } else if file_type.is_file() {
+                files.push(name);
             }
         }
 
@@ -2461,6 +2463,44 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_entry_name_rejects_non_utf8_names() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let result = directory_entry_name(OsString::from_vec(vec![b'b', 0xff]));
+
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn list_folder_skips_symlinks_to_files_and_directories() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-list-symlinks-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(root.join("real.pdf"), b"book").unwrap();
+        std::fs::create_dir(root.join("real-directory")).unwrap();
+        std::fs::write(outside.join("outside.pdf"), b"outside").unwrap();
+        symlink(&outside, root.join("linked-directory")).unwrap();
+        symlink(outside.join("outside.pdf"), root.join("linked-file.pdf")).unwrap();
+        let store = FileSystemStore::new(root.to_str().unwrap());
+
+        let listing = store.list_folder("").await.unwrap();
+
+        assert_eq!(listing.0, vec!["real-directory"]);
+        assert_eq!(listing.1, vec!["real.pdf"]);
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[tokio::test]

--- a/src/adaptors/object_store.rs
+++ b/src/adaptors/object_store.rs
@@ -1054,13 +1054,13 @@ impl FileStore for FileSystemStore {
         }
 
         let mut read_dir = fs::read_dir(path).await?;
-        while let Some(entry) = read_dir.next_entry().await? {
-            let name = directory_entry_name(entry.file_name())?;
-            let file_type = entry.file_type().await?;
-            if file_type.is_dir() {
-                directories.push(name);
-            } else if file_type.is_file() {
-                files.push(name);
+        while let Ok(Some(entry)) = read_dir.next_entry().await {
+            if let Ok(name) = entry.file_name().into_string() {
+                if entry.path().is_dir() {
+                    directories.push(name);
+                } else {
+                    files.push(name);
+                }
             }
         }
 
@@ -1068,6 +1068,50 @@ impl FileStore for FileSystemStore {
         files.sort();
 
         Ok((directories, files))
+    }
+
+    async fn list_folder_no_follow(&self, path: &str) -> Result<(Vec<String>, Vec<String>)> {
+        let store = self.clone();
+        let requested = PathBuf::from(path);
+        tokio::task::spawn_blocking(move || {
+            let mut components = Vec::new();
+            for component in requested.components() {
+                match component {
+                    Component::Normal(component) => components.push(component.to_os_string()),
+                    Component::CurDir
+                    | Component::ParentDir
+                    | Component::Prefix(_)
+                    | Component::RootDir => {
+                        return Err(anyhow!(
+                            "strict directory listing requires a relative path of normal components: {}",
+                            requested.display()
+                        ));
+                    }
+                }
+            }
+
+            let mut directory = store.open_root()?.try_clone()?;
+            for component in components {
+                directory = directory.open_dir_nofollow(Path::new(&component))?;
+            }
+
+            let mut directories = Vec::new();
+            let mut files = Vec::new();
+            for entry in directory.entries()? {
+                let entry = entry?;
+                let name = directory_entry_name(entry.file_name())?;
+                let file_type = entry.file_type()?;
+                if file_type.is_dir() {
+                    directories.push(name);
+                } else if file_type.is_file() {
+                    files.push(name);
+                }
+            }
+            directories.sort();
+            files.sort();
+            Ok((directories, files))
+        })
+        .await?
     }
 
     async fn ensure_path_exists(&self, _path: &str) -> Result<()> {
@@ -2477,7 +2521,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn list_folder_skips_symlinks_to_files_and_directories() {
+    async fn strict_list_folder_skips_symlinks_to_files_and_directories() {
         use std::os::unix::fs::symlink;
 
         let base = std::env::temp_dir().join(format!(
@@ -2496,10 +2540,36 @@ mod tests {
         symlink(outside.join("outside.pdf"), root.join("linked-file.pdf")).unwrap();
         let store = FileSystemStore::new(root.to_str().unwrap());
 
-        let listing = store.list_folder("").await.unwrap();
+        let listing = store.list_folder_no_follow("").await.unwrap();
 
         assert_eq!(listing.0, vec!["real-directory"]);
         assert_eq!(listing.1, vec!["real.pdf"]);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn legacy_list_folder_preserves_symlink_behavior_for_video_callers() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "tvserver-legacy-list-symlinks-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let root = base.join("root");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("outside.mp4"), b"outside").unwrap();
+        symlink(&outside, root.join("linked-directory")).unwrap();
+        symlink(outside.join("outside.mp4"), root.join("linked-file.mp4")).unwrap();
+        let store = FileSystemStore::new(root.to_str().unwrap());
+
+        let listing = store.list_folder("").await.unwrap();
+
+        assert_eq!(listing.0, vec!["linked-directory"]);
+        assert_eq!(listing.1, vec!["linked-file.mp4"]);
         let _ = std::fs::remove_dir_all(&base);
     }
 

--- a/src/adaptors/repository.rs
+++ b/src/adaptors/repository.rs
@@ -347,6 +347,34 @@ impl Databaser for SqlRepository {
         Ok(rows_affected)
     }
 
+    async fn delete_book_if_path_matches(
+        &self,
+        checksum: i64,
+        collection: &str,
+        file_name: &str,
+    ) -> Result<u64, sqlx::Error> {
+        let rows_affected = sqlx::query(
+            "DELETE FROM books WHERE checksum = ? AND collection = ? AND file_name = ?",
+        )
+        .bind(checksum)
+        .bind(collection)
+        .bind(file_name)
+        .execute(&self.pool)
+        .await?
+        .rows_affected();
+
+        if rows_affected > 0 {
+            if let Some(sender) = &self.sender {
+                let message = LocalMessage::Book(BookEvent::new_book_deleted_event(checksum));
+                if let Err(error) = sender.send(message).await {
+                    tracing::error!("Error sending book deleted event {} {}", checksum, error);
+                }
+            }
+        }
+
+        Ok(rows_affected)
+    }
+
     async fn save_video(&self, details: &VideoDetails) -> Result<i64, sqlx::Error> {
         // Use a transaction so the existence check and upsert are atomic
         let mut tx = self.pool.begin().await?;
@@ -1207,6 +1235,48 @@ mod tests {
         assert!(deleted.book.is_none());
 
         assert_eq!(db.delete_book(book.checksum).await.unwrap(), 0);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn conditional_book_delete_preserves_relocated_checksum_and_emits_only_on_match() {
+        let (sender, mut receiver) = mpsc::channel(4);
+        let db = SqlRepository::new(MEMORY_DB_URL, Some(sender))
+            .await
+            .unwrap();
+        let original = sample_book(802, "Old", "Dune.epub", "Dune");
+        db.save_book(&original).await.unwrap();
+        receiver.try_recv().unwrap();
+
+        let relocated = sample_book(802, "New", "Dune.epub", "Dune");
+        db.save_book(&relocated).await.unwrap();
+        receiver.try_recv().unwrap();
+
+        assert_eq!(
+            db.delete_book_if_path_matches(802, "Old", "Dune.epub")
+                .await
+                .unwrap(),
+            0
+        );
+        let current = db.retrieve_book(802).await.unwrap();
+        assert_eq!(current.collection, "New");
+        assert!(receiver.try_recv().is_err());
+
+        assert_eq!(
+            db.delete_book_if_path_matches(802, "New", "Dune.epub")
+                .await
+                .unwrap(),
+            1
+        );
+        assert!(matches!(
+            db.retrieve_book(802).await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+        let LocalMessage::Book(deleted) = receiver.try_recv().unwrap() else {
+            panic!("expected a book event");
+        };
+        assert_eq!(deleted.event_type, BookEventType::BookEventDeleted);
+        assert_eq!(deleted.checksum, "802");
         assert!(receiver.try_recv().is_err());
     }
 

--- a/src/domain/algorithm/naming.rs
+++ b/src/domain/algorithm/naming.rs
@@ -108,11 +108,19 @@ pub fn get_book_collection_from_path(path: &Path) -> String {
 pub fn path_to_collection_id(path: &Path) -> Option<String> {
     path.components()
         .map(|component| match component {
-            Component::Normal(part) => part.to_str(),
+            Component::Normal(part) => part.to_str().filter(|segment| is_portable_segment(segment)),
             _ => None,
         })
         .collect::<Option<Vec<_>>>()
         .map(|components| components.join("/"))
+}
+
+fn is_portable_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment != "."
+        && segment != ".."
+        && !segment.contains('\\')
+        && !segment.contains(':')
 }
 
 pub fn collection_id_to_path(collection: &str) -> Option<PathBuf> {
@@ -122,12 +130,7 @@ pub fn collection_id_to_path(collection: &str) -> Option<PathBuf> {
 
     let mut path = PathBuf::new();
     for segment in collection.split('/') {
-        if segment.is_empty()
-            || segment == "."
-            || segment == ".."
-            || segment.contains('\\')
-            || segment.contains(':')
-        {
+        if !is_portable_segment(segment) {
             return None;
         }
         path.push(segment);
@@ -362,6 +365,25 @@ mod test {
                 "expected {collection:?} to be rejected"
             );
         }
+    }
+
+    #[test]
+    fn path_to_collection_id_rejects_nonportable_normal_segments() {
+        for path in [Path::new(r"Fiction\Classics"), Path::new("Fiction:Classics")] {
+            assert_eq!(
+                path_to_collection_id(path),
+                None,
+                "expected {path:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn every_produced_collection_id_round_trips() {
+        let path = Path::new("Fiction").join("Classics").join("British");
+        let collection = path_to_collection_id(&path).expect("portable path should convert");
+
+        assert_eq!(collection_id_to_path(&collection), Some(path));
     }
 
     #[cfg(windows)]

--- a/src/domain/services/book_check.rs
+++ b/src/domain/services/book_check.rs
@@ -47,19 +47,39 @@ impl BookCheck {
             .map(|book| ((book.collection.clone(), book.file_name.clone()), book.state))
             .collect();
         let mut disk_books = HashSet::new();
-        self.process_collection(PathBuf::new(), &known_books, &mut disk_books)
-            .await?;
+        let mut pending_events = Vec::new();
+        self.process_collection(
+            PathBuf::new(),
+            &known_books,
+            &mut disk_books,
+            &mut pending_events,
+        )
+        .await?;
 
         for book in books {
             if disk_books.contains(&(book.collection.clone(), book.file_name.clone())) {
                 continue;
             }
-            if let Err(error) = self.repo.delete_book(book.checksum).await {
+            if let Err(error) = self
+                .repo
+                .delete_book_if_path_matches(
+                    book.checksum,
+                    &book.collection,
+                    &book.file_name,
+                )
+                .await
+            {
                 tracing::error!(
                     "error deleting orphaned book {} ({}): {error}",
                     book.file_name,
                     book.checksum
                 );
+            }
+        }
+
+        for event in pending_events {
+            if let Err(error) = self.sender.send(LocalMessage::Media(event)).await {
+                tracing::error!("could not queue book Media event: {error}");
             }
         }
 
@@ -72,6 +92,7 @@ impl BookCheck {
         relative_collection: PathBuf,
         known_books: &HashMap<(String, String), BookState>,
         disk_books: &mut HashSet<(String, String)>,
+        pending_events: &mut Vec<MediaEvent>,
     ) -> anyhow::Result<()> {
         let collection = path_to_collection_id(&relative_collection)
             .ok_or_else(|| anyhow::anyhow!("book collection is not a portable path"))?;
@@ -81,8 +102,13 @@ impl BookCheck {
             if relative_collection.as_os_str().is_empty() && directory == ".thumbnails" {
                 continue;
             }
-            self.process_collection(relative_collection.join(directory), known_books, disk_books)
-                .await?;
+            self.process_collection(
+                relative_collection.join(directory),
+                known_books,
+                disk_books,
+                pending_events,
+            )
+            .await?;
         }
 
         for file_name in files {
@@ -103,9 +129,7 @@ impl BookCheck {
 
             let path = self.book_root.join(&relative_collection).join(file_name);
             let event = MediaEvent::new_media(&path, None);
-            if let Err(error) = self.sender.send(LocalMessage::Media(event)).await {
-                tracing::error!("could not queue book Media event: {error}");
-            }
+            pending_events.push(event);
         }
 
         Ok(())
@@ -125,7 +149,7 @@ mod tests {
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicU64, Ordering},
-            Arc,
+            Arc, Mutex,
         },
     };
 
@@ -152,20 +176,25 @@ mod tests {
 
     struct TestDir(PathBuf);
 
-    struct FailingNestedListStore {
+    struct ControlledListStore {
         inner: FileStorer,
-        failing_collection: String,
+        failing_collection: Option<String>,
+        relocation: Mutex<Option<(Repository, BookDetails)>>,
     }
 
     #[async_trait::async_trait]
-    impl FileStore for FailingNestedListStore {
+    impl FileStore for ControlledListStore {
         async fn create_folder(&self, path: &Path) -> anyhow::Result<()> {
             self.inner.create_folder(path).await
         }
 
         async fn list_folder(&self, path: &str) -> anyhow::Result<(Vec<String>, Vec<String>)> {
-            if path == self.failing_collection {
+            if self.failing_collection.as_deref() == Some(path) {
                 anyhow::bail!("forced nested list failure for {path}");
+            }
+            let relocation = self.relocation.lock().unwrap().take();
+            if let Some((repository, book)) = relocation {
+                repository.save_book(&book).await?;
             }
             self.inner.list_folder(path).await
         }
@@ -479,9 +508,10 @@ mod tests {
         repository.save_book(&orphan).await.unwrap();
 
         let inner: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
-        let storer: FileStorer = Arc::new(FailingNestedListStore {
+        let storer: FileStorer = Arc::new(ControlledListStore {
             inner,
-            failing_collection: "broken".to_string(),
+            failing_collection: Some("broken".to_string()),
+            relocation: Mutex::new(None),
         });
         let (sender, _receiver) = mpsc::channel(8);
         let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
@@ -490,5 +520,150 @@ mod tests {
 
         assert!(error.to_string().contains("forced nested list failure"));
         assert_eq!(repository.retrieve_book(301).await.unwrap().file_name, "missing.pdf");
+    }
+
+    #[tokio::test]
+    async fn preserves_checksum_relocated_after_scanner_snapshot() {
+        let root = TestDir::new("relocation-race");
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let mut original = BookDetails::new(
+            "Dune.epub".to_string(),
+            "Old".to_string(),
+            &root.path().join("Old/Dune.epub"),
+            BookFormat::Epub,
+        );
+        original.checksum = 401;
+        original.state = BookState::Ready;
+        repository.save_book(&original).await.unwrap();
+        let mut relocated = original.clone();
+        relocated.collection = "New".to_string();
+        relocated.file_name = "Relocated.epub".to_string();
+
+        let inner: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let storer: FileStorer = Arc::new(ControlledListStore {
+            inner,
+            failing_collection: None,
+            relocation: Mutex::new(Some((repository.clone(), relocated))),
+        });
+        let (sender, _receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
+
+        checker.check_book_information().await.unwrap();
+
+        let current = repository.retrieve_book(401).await.unwrap();
+        assert_eq!(current.collection, "New");
+        assert_eq!(current.file_name, "Relocated.epub");
+    }
+
+    #[tokio::test]
+    async fn publishes_scanner_events_only_after_orphan_reconciliation() {
+        let root = TestDir::new("event-order");
+        let new_path = root.path().join("new.pdf");
+        tokio::fs::write(&new_path, b"book").await.unwrap();
+        let (sender, mut receiver) = mpsc::channel(8);
+        let repository: Repository =
+            Arc::new(SqlRepository::new(":memory:", Some(sender.clone())).await.unwrap());
+        let mut orphan = BookDetails::new(
+            "missing.epub".to_string(),
+            "Missing".to_string(),
+            &root.path().join("Missing/missing.epub"),
+            BookFormat::Epub,
+        );
+        orphan.checksum = 402;
+        orphan.state = BookState::Ready;
+        repository.save_book(&orphan).await.unwrap();
+        receiver.try_recv().unwrap();
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let checker = BookCheck::new_with_root(storer, repository, sender, root.path());
+
+        checker.check_book_information().await.unwrap();
+
+        let LocalMessage::Book(deleted) = receiver.try_recv().expect("delete event first") else {
+            panic!("orphan reconciliation must happen before scanner publication");
+        };
+        assert_eq!(deleted.checksum, "402");
+        let LocalMessage::Media(MediaEvent::MediaAvailable(available)) =
+            receiver.try_recv().expect("media event second")
+        else {
+            panic!("expected scanner media event after reconciliation");
+        };
+        assert_eq!(available.full_path, new_path);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn invalid_collection_after_valid_book_fails_without_delete_or_publication() {
+        let root = TestDir::new("invalid-collection");
+        tokio::fs::create_dir_all(root.path().join("a-good")).await.unwrap();
+        tokio::fs::write(root.path().join("a-good/new.pdf"), b"book")
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(root.path().join("z:invalid"))
+            .await
+            .unwrap();
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let mut orphan = BookDetails::new(
+            "missing.pdf".to_string(),
+            "missing".to_string(),
+            &root.path().join("missing/missing.pdf"),
+            BookFormat::Pdf,
+        );
+        orphan.checksum = 403;
+        orphan.state = BookState::Ready;
+        repository.save_book(&orphan).await.unwrap();
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let (sender, mut receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
+
+        let error = checker.check_book_information().await.unwrap_err();
+
+        assert!(error.to_string().contains("portable path"));
+        assert!(receiver.try_recv().is_err());
+        assert_eq!(repository.retrieve_book(403).await.unwrap().file_name, "missing.pdf");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn skips_external_directory_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestDir::new("external-symlink-root");
+        let outside = TestDir::new("external-symlink-target");
+        let outside_book = outside.path().join("outside.pdf");
+        tokio::fs::write(&outside_book, b"outside").await.unwrap();
+        symlink(outside.path(), root.path().join("linked-outside")).unwrap();
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let (sender, mut receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository, sender, root.path());
+
+        timeout(Duration::from_secs(1), checker.check_book_information())
+            .await
+            .expect("scan should complete")
+            .unwrap();
+
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn skips_cyclic_directory_symlink_and_completes() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestDir::new("cyclic-symlink");
+        let nested = root.path().join("nested");
+        tokio::fs::create_dir_all(&nested).await.unwrap();
+        symlink(root.path(), nested.join("cycle")).unwrap();
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let (sender, mut receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository, sender, root.path());
+
+        timeout(Duration::from_secs(1), checker.check_book_information())
+            .await
+            .expect("cyclic symlink must not recurse forever")
+            .unwrap();
+
+        assert!(receiver.try_recv().is_err());
     }
 }

--- a/src/domain/services/book_check.rs
+++ b/src/domain/services/book_check.rs
@@ -1,0 +1,319 @@
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
+
+use async_recursion::async_recursion;
+
+use crate::domain::{
+    algorithm::{classify_media_kind, path_to_collection_id, MediaKind},
+    config::get_book_dir,
+    messages::{LocalMessage, LocalMessageSender, MediaEvent},
+    models::BookState,
+    traits::{BookChecker, FileStorer, Repository},
+};
+
+#[derive(Clone)]
+pub struct BookCheck {
+    store: FileStorer,
+    repo: Repository,
+    sender: LocalMessageSender,
+    book_root: PathBuf,
+}
+
+impl BookCheck {
+    pub fn new(store: FileStorer, repo: Repository, sender: LocalMessageSender) -> Self {
+        Self::new_with_root(store, repo, sender, get_book_dir())
+    }
+
+    pub fn new_with_root(
+        store: FileStorer,
+        repo: Repository,
+        sender: LocalMessageSender,
+        book_root: impl AsRef<Path>,
+    ) -> Self {
+        Self {
+            store,
+            repo,
+            sender,
+            book_root: book_root.as_ref().to_path_buf(),
+        }
+    }
+
+    async fn scan(&self) -> anyhow::Result<()> {
+        let books = self.repo.list_all_books().await?;
+        let known_books = books
+            .iter()
+            .map(|book| ((book.collection.clone(), book.file_name.clone()), book.state))
+            .collect();
+        let mut disk_books = HashSet::new();
+        self.process_collection(PathBuf::new(), &known_books, &mut disk_books)
+            .await?;
+
+        for book in books {
+            if disk_books.contains(&(book.collection.clone(), book.file_name.clone())) {
+                continue;
+            }
+            if let Err(error) = self.repo.delete_book(book.checksum).await {
+                tracing::error!(
+                    "error deleting orphaned book {} ({}): {error}",
+                    book.file_name,
+                    book.checksum
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[async_recursion]
+    async fn process_collection(
+        &self,
+        relative_collection: PathBuf,
+        known_books: &HashMap<(String, String), BookState>,
+        disk_books: &mut HashSet<(String, String)>,
+    ) -> anyhow::Result<()> {
+        let collection = path_to_collection_id(&relative_collection)
+            .ok_or_else(|| anyhow::anyhow!("book collection is not a portable path"))?;
+        let (directories, files) = self.store.list_folder(&collection).await?;
+
+        for directory in directories {
+            if directory.starts_with('.') {
+                continue;
+            }
+            self.process_collection(relative_collection.join(directory), known_books, disk_books)
+                .await?;
+        }
+
+        for file_name in files {
+            if classify_media_kind(&file_name) != MediaKind::Book {
+                continue;
+            }
+
+            disk_books.insert((collection.clone(), file_name.clone()));
+
+            let should_queue = match known_books.get(&(collection.clone(), file_name.clone())) {
+                None => true,
+                Some(BookState::NeedMetadata | BookState::MetadataError) => true,
+                Some(_) => false,
+            };
+            if !should_queue {
+                continue;
+            }
+
+            let path = self.book_root.join(&relative_collection).join(file_name);
+            let event = MediaEvent::new_media(&path, None);
+            if let Err(error) = self.sender.send(LocalMessage::Media(event)).await {
+                tracing::error!("could not queue book Media event: {error}");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl BookChecker for BookCheck {
+    async fn check_book_information(&self) -> anyhow::Result<()> {
+        self.scan().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::{Path, PathBuf},
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc,
+        },
+    };
+
+    use crate::{
+        adaptors::{FileSystemStore, SqlRepository},
+        domain::{
+            messages::{LocalMessage, MediaEvent},
+            models::{BookDetails, BookFormat, BookState},
+            traits::{BookChecker, FileStorer, Repository},
+        },
+    };
+    use tokio::{
+        sync::mpsc,
+        time::{timeout, Duration},
+    };
+
+    use super::BookCheck;
+
+    static NEXT_TEST_DIR: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "tvserver-book-check-{name}-{}-{}",
+                std::process::id(),
+                NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn queues_new_book_in_recursive_collection() {
+        let root = TestDir::new("new-recursive");
+        let book_path = root.path().join("Fiction").join("Sci-Fi").join("Dune.EPUB");
+        tokio::fs::create_dir_all(book_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&book_path, b"epub").await.unwrap();
+
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let (sender, mut receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository, sender, root.path());
+
+        checker.check_book_information().await.unwrap();
+
+        let message = timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("new book should be queued")
+            .expect("scanner sender should stay open");
+        let LocalMessage::Media(MediaEvent::MediaAvailable(event)) = message else {
+            panic!("expected MediaAvailable event");
+        };
+        assert_eq!(event.full_path, book_path);
+        assert_eq!(event.search, None);
+    }
+
+    #[tokio::test]
+    async fn skips_unsupported_files_and_generated_thumbnail_directory() {
+        let root = TestDir::new("unsupported");
+        tokio::fs::create_dir_all(root.path().join(".thumbnails"))
+            .await
+            .unwrap();
+        for relative_path in [
+            "book.pdf",
+            "book.epub",
+            "notes.txt",
+            "cover.jpg",
+            "movie.mp4",
+            ".thumbnails/generated.pdf",
+        ] {
+            tokio::fs::write(root.path().join(relative_path), b"data")
+                .await
+                .unwrap();
+        }
+
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let (sender, mut receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository, sender, root.path());
+
+        checker.check_book_information().await.unwrap();
+
+        let mut queued = Vec::new();
+        while let Ok(LocalMessage::Media(MediaEvent::MediaAvailable(event))) = receiver.try_recv() {
+            queued.push(event.full_path);
+        }
+        queued.sort();
+        assert_eq!(
+            queued,
+            vec![root.path().join("book.epub"), root.path().join("book.pdf")]
+        );
+    }
+
+    #[tokio::test]
+    async fn queues_only_need_metadata_and_metadata_error_books_for_retry() {
+        let root = TestDir::new("retries");
+        let collection_dir = root.path().join("Fiction").join("Sci-Fi");
+        tokio::fs::create_dir_all(&collection_dir).await.unwrap();
+
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        for (checksum, file_name, state) in [
+            (101, "need.pdf", BookState::NeedMetadata),
+            (102, "error.epub", BookState::MetadataError),
+            (103, "ready.pdf", BookState::Ready),
+        ] {
+            let path = collection_dir.join(file_name);
+            tokio::fs::write(&path, b"book").await.unwrap();
+            let format = if file_name.ends_with("epub") {
+                BookFormat::Epub
+            } else {
+                BookFormat::Pdf
+            };
+            let mut book = BookDetails::new(
+                file_name.to_string(),
+                "Fiction/Sci-Fi".to_string(),
+                &path,
+                format,
+            );
+            book.checksum = checksum;
+            book.state = state;
+            repository.save_book(&book).await.unwrap();
+        }
+
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let (sender, mut receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository, sender, root.path());
+
+        checker.check_book_information().await.unwrap();
+
+        let mut queued = Vec::new();
+        while let Ok(LocalMessage::Media(MediaEvent::MediaAvailable(event))) = receiver.try_recv() {
+            queued.push(event.full_path);
+        }
+        queued.sort();
+        assert_eq!(
+            queued,
+            vec![collection_dir.join("error.epub"), collection_dir.join("need.pdf")]
+        );
+    }
+
+    #[tokio::test]
+    async fn deletes_orphaned_book_rows_and_preserves_present_books() {
+        let root = TestDir::new("orphans");
+        let collection_dir = root.path().join("Reference");
+        tokio::fs::create_dir_all(&collection_dir).await.unwrap();
+        let present_path = collection_dir.join("present.pdf");
+        tokio::fs::write(&present_path, b"book").await.unwrap();
+
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        for (checksum, file_name, path) in [
+            (201, "present.pdf", present_path.clone()),
+            (202, "missing.epub", collection_dir.join("missing.epub")),
+        ] {
+            let format = if file_name.ends_with("epub") {
+                BookFormat::Epub
+            } else {
+                BookFormat::Pdf
+            };
+            let mut book =
+                BookDetails::new(file_name.to_string(), "Reference".to_string(), &path, format);
+            book.checksum = checksum;
+            book.state = BookState::Ready;
+            repository.save_book(&book).await.unwrap();
+        }
+
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let (sender, _receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
+
+        checker.check_book_information().await.unwrap();
+
+        let books = repository.list_all_books().await.unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].checksum, 201);
+    }
+}

--- a/src/domain/services/book_check.rs
+++ b/src/domain/services/book_check.rs
@@ -96,7 +96,7 @@ impl BookCheck {
     ) -> anyhow::Result<()> {
         let collection = path_to_collection_id(&relative_collection)
             .ok_or_else(|| anyhow::anyhow!("book collection is not a portable path"))?;
-        let (directories, files) = self.store.list_folder(&collection).await?;
+        let (directories, files) = self.store.list_folder_no_follow(&collection).await?;
 
         for directory in directories {
             if relative_collection.as_os_str().is_empty() && directory == ".thumbnails" {
@@ -180,6 +180,9 @@ mod tests {
         inner: FileStorer,
         failing_collection: Option<String>,
         relocation: Mutex<Option<(Repository, BookDetails)>>,
+        directory_swap: Mutex<Option<(String, PathBuf, PathBuf)>>,
+        legacy_calls: AtomicU64,
+        strict_calls: AtomicU64,
     }
 
     #[async_trait::async_trait]
@@ -189,14 +192,43 @@ mod tests {
         }
 
         async fn list_folder(&self, path: &str) -> anyhow::Result<(Vec<String>, Vec<String>)> {
+            self.legacy_calls.fetch_add(1, Ordering::Relaxed);
+            self.inner.list_folder(path).await
+        }
+
+        async fn list_folder_no_follow(
+            &self,
+            path: &str,
+        ) -> anyhow::Result<(Vec<String>, Vec<String>)> {
+            self.strict_calls.fetch_add(1, Ordering::Relaxed);
             if self.failing_collection.as_deref() == Some(path) {
                 anyhow::bail!("forced nested list failure for {path}");
             }
+            let swap = {
+                let mut swap = self.directory_swap.lock().unwrap();
+                if swap
+                    .as_ref()
+                    .is_some_and(|(collection, _, _)| collection == path)
+                {
+                    swap.take()
+                } else {
+                    None
+                }
+            };
+            #[cfg(unix)]
+            if let Some((_, original, replacement)) = swap {
+                use std::os::unix::fs::symlink;
+
+                std::fs::remove_dir(&original)?;
+                symlink(replacement, original)?;
+            }
+            #[cfg(not(unix))]
+            let _ = swap;
             let relocation = self.relocation.lock().unwrap().take();
             if let Some((repository, book)) = relocation {
                 repository.save_book(&book).await?;
             }
-            self.inner.list_folder(path).await
+            self.inner.list_folder_no_follow(path).await
         }
 
         async fn ensure_path_exists(&self, path: &str) -> anyhow::Result<()> {
@@ -512,6 +544,9 @@ mod tests {
             inner,
             failing_collection: Some("broken".to_string()),
             relocation: Mutex::new(None),
+            directory_swap: Mutex::new(None),
+            legacy_calls: AtomicU64::new(0),
+            strict_calls: AtomicU64::new(0),
         });
         let (sender, _receiver) = mpsc::channel(8);
         let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
@@ -544,6 +579,9 @@ mod tests {
             inner,
             failing_collection: None,
             relocation: Mutex::new(Some((repository.clone(), relocated))),
+            directory_swap: Mutex::new(None),
+            legacy_calls: AtomicU64::new(0),
+            strict_calls: AtomicU64::new(0),
         });
         let (sender, _receiver) = mpsc::channel(8);
         let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
@@ -588,6 +626,63 @@ mod tests {
             panic!("expected scanner media event after reconciliation");
         };
         assert_eq!(available.full_path, new_path);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn directory_swapped_to_external_symlink_before_recursive_open_fails_closed() {
+        let root = TestDir::new("directory-swap-root");
+        let outside = TestDir::new("directory-swap-outside");
+        let child = root.path().join("swapped");
+        std::fs::create_dir(&child).unwrap();
+        let external_book = outside.path().join("external.pdf");
+        std::fs::write(&external_book, b"external").unwrap();
+
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let orphan_path = root.path().join("missing/missing.epub");
+        let mut orphan = BookDetails::new(
+            "missing.epub".to_string(),
+            "missing".to_string(),
+            &orphan_path,
+            BookFormat::Epub,
+        );
+        orphan.checksum = 404;
+        orphan.state = BookState::Ready;
+        repository.save_book(&orphan).await.unwrap();
+
+        let inner: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let controlled = Arc::new(ControlledListStore {
+            inner,
+            failing_collection: None,
+            relocation: Mutex::new(None),
+            directory_swap: Mutex::new(Some((
+                "swapped".to_string(),
+                child.clone(),
+                outside.path().to_path_buf(),
+            ))),
+            legacy_calls: AtomicU64::new(0),
+            strict_calls: AtomicU64::new(0),
+        });
+        let storer: FileStorer = controlled.clone();
+        let (sender, mut receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
+
+        let result = timeout(Duration::from_secs(1), checker.check_book_information())
+            .await
+            .expect("scanner must not hang after the directory swap");
+
+        assert!(result.is_err(), "the swapped recursive open must fail closed");
+        assert!(std::fs::symlink_metadata(&child)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(controlled.strict_calls.load(Ordering::Relaxed) >= 2);
+        assert_eq!(controlled.legacy_calls.load(Ordering::Relaxed), 0);
+        assert!(receiver.try_recv().is_err(), "external book must not be queued");
+        assert_eq!(
+            repository.retrieve_book(404).await.unwrap().file_name,
+            "missing.epub"
+        );
     }
 
     #[cfg(unix)]

--- a/src/domain/services/book_check.rs
+++ b/src/domain/services/book_check.rs
@@ -110,6 +110,9 @@ impl BookCheck {
                 );
                 continue;
             };
+            if self.store.regular_file_exists_no_follow(&full_path).await? {
+                continue;
+            }
             if let Err(error) = self
                 .repo
                 .delete_book_if_path_matches(
@@ -216,7 +219,7 @@ mod tests {
         },
     };
     use tokio::{
-        sync::mpsc,
+        sync::{mpsc, Notify},
         time::{timeout, Duration},
     };
 
@@ -232,8 +235,16 @@ mod tests {
         failing_collection: Option<String>,
         relocation: Mutex<Option<(Repository, BookDetails)>>,
         directory_swap: Mutex<Option<(String, PathBuf, PathBuf)>>,
+        traversal_hook: Option<Arc<TraversalHook>>,
+        inspection_error: bool,
         legacy_calls: AtomicU64,
         strict_calls: AtomicU64,
+    }
+
+    struct TraversalHook {
+        collection: String,
+        listed: Notify,
+        proceed: Notify,
     }
 
     #[async_trait::async_trait]
@@ -279,7 +290,14 @@ mod tests {
             if let Some((repository, book)) = relocation {
                 repository.save_book(&book).await?;
             }
-            self.inner.list_folder_no_follow(path).await
+            let listing = self.inner.list_folder_no_follow(path).await?;
+            if let Some(hook) = &self.traversal_hook {
+                if path == hook.collection {
+                    hook.listed.notify_one();
+                    hook.proceed.notified().await;
+                }
+            }
+            Ok(listing)
         }
 
         async fn ensure_path_exists(&self, path: &str) -> anyhow::Result<()> {
@@ -331,6 +349,9 @@ mod tests {
         }
 
         async fn regular_file_exists_no_follow(&self, path: &Path) -> anyhow::Result<bool> {
+            if self.inspection_error {
+                anyhow::bail!("forced exact-path inspection failure");
+            }
             self.inner.regular_file_exists_no_follow(path).await
         }
 
@@ -630,6 +651,126 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restored_original_after_traversal_is_not_deleted_during_reconciliation() {
+        let root = TestDir::new("restored-after-traversal");
+        let collection_dir = root.path().join("Reference");
+        tokio::fs::create_dir_all(&collection_dir).await.unwrap();
+        let original_path = collection_dir.join("retry.epub");
+        let staged_path = collection_dir.join(".tvserver-ingest-test");
+        tokio::fs::write(&original_path, b"book").await.unwrap();
+
+        let (sender, mut receiver) = mpsc::channel(8);
+        let repository: Repository = Arc::new(
+            SqlRepository::new(":memory:", Some(sender.clone()))
+                .await
+                .unwrap(),
+        );
+        let mut book = BookDetails::new(
+            "retry.epub".to_string(),
+            "Reference".to_string(),
+            &original_path,
+            BookFormat::Epub,
+        );
+        book.checksum = 204;
+        book.state = BookState::MetadataError;
+        repository.save_book(&book).await.unwrap();
+        receiver.try_recv().unwrap();
+
+        let leases = BookPathLeaseCoordinator::new();
+        let processing = leases.acquire_processing(&original_path).await;
+        tokio::fs::rename(&original_path, &staged_path)
+            .await
+            .unwrap();
+        let hook = Arc::new(TraversalHook {
+            collection: "Reference".to_string(),
+            listed: Notify::new(),
+            proceed: Notify::new(),
+        });
+        let inner: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let storer: FileStorer = Arc::new(ControlledListStore {
+            inner,
+            failing_collection: None,
+            relocation: Mutex::new(None),
+            directory_swap: Mutex::new(None),
+            traversal_hook: Some(hook.clone()),
+            inspection_error: false,
+            legacy_calls: AtomicU64::new(0),
+            strict_calls: AtomicU64::new(0),
+        });
+        let checker = BookCheck::new_with_root_and_leases(
+            storer,
+            repository.clone(),
+            sender,
+            root.path(),
+            leases,
+        );
+
+        let scan = tokio::spawn(async move { checker.check_book_information().await });
+        hook.listed.notified().await;
+        tokio::fs::rename(&staged_path, &original_path)
+            .await
+            .unwrap();
+        drop(processing);
+        hook.proceed.notify_one();
+        scan.await.unwrap().unwrap();
+
+        assert_eq!(
+            repository.retrieve_book(204).await.unwrap().file_name,
+            "retry.epub"
+        );
+        assert!(receiver.try_recv().is_err(), "scanner must emit no delete event");
+    }
+
+    #[tokio::test]
+    async fn exact_path_inspection_error_preserves_row_and_pending_events() {
+        let root = TestDir::new("inspection-error");
+        let new_path = root.path().join("new.pdf");
+        tokio::fs::write(&new_path, b"book").await.unwrap();
+        let (sender, mut receiver) = mpsc::channel(8);
+        let repository: Repository = Arc::new(
+            SqlRepository::new(":memory:", Some(sender.clone()))
+                .await
+                .unwrap(),
+        );
+        let mut orphan = BookDetails::new(
+            "missing.epub".to_string(),
+            "Missing".to_string(),
+            &root.path().join("Missing/missing.epub"),
+            BookFormat::Epub,
+        );
+        orphan.checksum = 205;
+        orphan.state = BookState::Ready;
+        repository.save_book(&orphan).await.unwrap();
+        receiver.try_recv().unwrap();
+        let inner: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let storer: FileStorer = Arc::new(ControlledListStore {
+            inner,
+            failing_collection: None,
+            relocation: Mutex::new(None),
+            directory_swap: Mutex::new(None),
+            traversal_hook: None,
+            inspection_error: true,
+            legacy_calls: AtomicU64::new(0),
+            strict_calls: AtomicU64::new(0),
+        });
+        let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
+
+        let error = checker.check_book_information().await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("forced exact-path inspection failure"));
+        assert_eq!(
+            repository.retrieve_book(205).await.unwrap().file_name,
+            "missing.epub"
+        );
+        assert!(
+            receiver.try_recv().is_err(),
+            "pending scanner event must not be published"
+        );
+    }
+
+    #[tokio::test]
     async fn nested_list_failure_does_not_delete_orphan_rows() {
         let root = TestDir::new("nested-list-failure");
         let collection_dir = root.path().join("broken");
@@ -653,6 +794,8 @@ mod tests {
             failing_collection: Some("broken".to_string()),
             relocation: Mutex::new(None),
             directory_swap: Mutex::new(None),
+            traversal_hook: None,
+            inspection_error: false,
             legacy_calls: AtomicU64::new(0),
             strict_calls: AtomicU64::new(0),
         });
@@ -688,6 +831,8 @@ mod tests {
             failing_collection: None,
             relocation: Mutex::new(Some((repository.clone(), relocated))),
             directory_swap: Mutex::new(None),
+            traversal_hook: None,
+            inspection_error: false,
             legacy_calls: AtomicU64::new(0),
             strict_calls: AtomicU64::new(0),
         });
@@ -768,6 +913,8 @@ mod tests {
                 child.clone(),
                 outside.path().to_path_buf(),
             ))),
+            traversal_hook: None,
+            inspection_error: false,
             legacy_calls: AtomicU64::new(0),
             strict_calls: AtomicU64::new(0),
         });

--- a/src/domain/services/book_check.rs
+++ b/src/domain/services/book_check.rs
@@ -5,8 +5,9 @@ use std::{
 
 use async_recursion::async_recursion;
 
+use crate::domain::services::BookPathLeaseCoordinator;
 use crate::domain::{
-    algorithm::{classify_media_kind, path_to_collection_id, MediaKind},
+    algorithm::{classify_media_kind, collection_id_to_path, path_to_collection_id, MediaKind},
     config::get_book_dir,
     messages::{LocalMessage, LocalMessageSender, MediaEvent},
     models::BookState,
@@ -19,11 +20,27 @@ pub struct BookCheck {
     repo: Repository,
     sender: LocalMessageSender,
     book_root: PathBuf,
+    leases: BookPathLeaseCoordinator,
 }
 
 impl BookCheck {
     pub fn new(store: FileStorer, repo: Repository, sender: LocalMessageSender) -> Self {
-        Self::new_with_root(store, repo, sender, get_book_dir())
+        Self::new_with_root_and_leases(
+            store,
+            repo,
+            sender,
+            get_book_dir(),
+            BookPathLeaseCoordinator::new(),
+        )
+    }
+
+    pub fn new_with_leases(
+        store: FileStorer,
+        repo: Repository,
+        sender: LocalMessageSender,
+        leases: BookPathLeaseCoordinator,
+    ) -> Self {
+        Self::new_with_root_and_leases(store, repo, sender, get_book_dir(), leases)
     }
 
     pub fn new_with_root(
@@ -32,11 +49,28 @@ impl BookCheck {
         sender: LocalMessageSender,
         book_root: impl AsRef<Path>,
     ) -> Self {
+        Self::new_with_root_and_leases(
+            store,
+            repo,
+            sender,
+            book_root,
+            BookPathLeaseCoordinator::new(),
+        )
+    }
+
+    pub fn new_with_root_and_leases(
+        store: FileStorer,
+        repo: Repository,
+        sender: LocalMessageSender,
+        book_root: impl AsRef<Path>,
+        leases: BookPathLeaseCoordinator,
+    ) -> Self {
         Self {
             store,
             repo,
             sender,
             book_root: book_root.as_ref().to_path_buf(),
+            leases,
         }
     }
 
@@ -60,6 +94,22 @@ impl BookCheck {
             if disk_books.contains(&(book.collection.clone(), book.file_name.clone())) {
                 continue;
             }
+            let Some(collection_path) = collection_id_to_path(&book.collection) else {
+                tracing::error!(
+                    "cannot reconcile book {} ({}): collection is not a portable path",
+                    book.file_name,
+                    book.checksum
+                );
+                continue;
+            };
+            let full_path = self.book_root.join(collection_path).join(&book.file_name);
+            let Some(_reconciling) = self.leases.try_acquire_reconciling(&full_path) else {
+                tracing::debug!(
+                    path = %full_path.display(),
+                    "Skipping orphan reconciliation while book ingestion is active"
+                );
+                continue;
+            };
             if let Err(error) = self
                 .repo
                 .delete_book_if_path_matches(
@@ -171,6 +221,7 @@ mod tests {
     };
 
     use super::BookCheck;
+    use crate::domain::services::BookPathLeaseCoordinator;
 
     static NEXT_TEST_DIR: AtomicU64 = AtomicU64::new(0);
 
@@ -519,6 +570,63 @@ mod tests {
         let books = repository.list_all_books().await.unwrap();
         assert_eq!(books.len(), 1);
         assert_eq!(books[0].checksum, 201);
+    }
+
+    #[tokio::test]
+    async fn active_ingestion_staging_does_not_delete_retry_row() {
+        let root = TestDir::new("active-ingestion-staging");
+        let collection_dir = root.path().join("Reference");
+        tokio::fs::create_dir_all(&collection_dir).await.unwrap();
+        let original_path = collection_dir.join("retry.epub");
+        let staged_path = collection_dir.join(".tvserver-ingest-test");
+        tokio::fs::write(&original_path, b"book").await.unwrap();
+
+        let (sender, mut receiver) = mpsc::channel(8);
+        let repository: Repository = Arc::new(
+            SqlRepository::new(":memory:", Some(sender.clone()))
+                .await
+                .unwrap(),
+        );
+        let mut book = BookDetails::new(
+            "retry.epub".to_string(),
+            "Reference".to_string(),
+            &original_path,
+            BookFormat::Epub,
+        );
+        book.checksum = 203;
+        book.state = BookState::MetadataError;
+        repository.save_book(&book).await.unwrap();
+        receiver.try_recv().unwrap();
+
+        let leases = BookPathLeaseCoordinator::new();
+        let processing = leases.acquire_processing(&original_path).await;
+        tokio::fs::rename(&original_path, &staged_path)
+            .await
+            .unwrap();
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let checker = BookCheck::new_with_root_and_leases(
+            storer,
+            repository.clone(),
+            sender,
+            root.path(),
+            leases,
+        );
+
+        checker.check_book_information().await.unwrap();
+
+        assert!(receiver.try_recv().is_err(), "scanner must emit no delete event");
+        assert_eq!(
+            repository.retrieve_book(203).await.unwrap().state,
+            BookState::MetadataError
+        );
+        tokio::fs::rename(&staged_path, &original_path)
+            .await
+            .unwrap();
+        drop(processing);
+        assert_eq!(
+            repository.retrieve_book(203).await.unwrap().file_name,
+            "retry.epub"
+        );
     }
 
     #[tokio::test]

--- a/src/domain/services/book_check.rs
+++ b/src/domain/services/book_check.rs
@@ -78,7 +78,7 @@ impl BookCheck {
         let (directories, files) = self.store.list_folder(&collection).await?;
 
         for directory in directories {
-            if directory.starts_with('.') {
+            if relative_collection.as_os_str().is_empty() && directory == ".thumbnails" {
                 continue;
             }
             self.process_collection(relative_collection.join(directory), known_books, disk_books)
@@ -132,9 +132,13 @@ mod tests {
     use crate::{
         adaptors::{FileSystemStore, SqlRepository},
         domain::{
+            algorithm::file_integrity::FileSeal,
             messages::{LocalMessage, MediaEvent},
             models::{BookDetails, BookFormat, BookState},
-            traits::{BookChecker, FileStorer, Repository},
+            traits::{
+                BookChecker, FileStore, FileStorer, PrivateSnapshot, Repository, StagedFile,
+                StoreObject,
+            },
         },
     };
     use tokio::{
@@ -147,6 +151,115 @@ mod tests {
     static NEXT_TEST_DIR: AtomicU64 = AtomicU64::new(0);
 
     struct TestDir(PathBuf);
+
+    struct FailingNestedListStore {
+        inner: FileStorer,
+        failing_collection: String,
+    }
+
+    #[async_trait::async_trait]
+    impl FileStore for FailingNestedListStore {
+        async fn create_folder(&self, path: &Path) -> anyhow::Result<()> {
+            self.inner.create_folder(path).await
+        }
+
+        async fn list_folder(&self, path: &str) -> anyhow::Result<(Vec<String>, Vec<String>)> {
+            if path == self.failing_collection {
+                anyhow::bail!("forced nested list failure for {path}");
+            }
+            self.inner.list_folder(path).await
+        }
+
+        async fn ensure_path_exists(&self, path: &str) -> anyhow::Result<()> {
+            self.inner.ensure_path_exists(path).await
+        }
+
+        async fn rename(&self, old_path: &str, new_path: &str) -> anyhow::Result<()> {
+            self.inner.rename(old_path, new_path).await
+        }
+
+        async fn rename_no_replace(&self, old_path: &str, new_path: &str) -> anyhow::Result<()> {
+            self.inner.rename_no_replace(old_path, new_path).await
+        }
+
+        async fn stage_no_follow(&self, source: &str) -> anyhow::Result<StagedFile> {
+            self.inner.stage_no_follow(source).await
+        }
+
+        async fn create_private_snapshot(
+            &self,
+            staged: &StagedFile,
+        ) -> anyhow::Result<PrivateSnapshot> {
+            self.inner.create_private_snapshot(staged).await
+        }
+
+        async fn seal_private_snapshot(
+            &self,
+            snapshot: &PrivateSnapshot,
+        ) -> anyhow::Result<FileSeal> {
+            self.inner.seal_private_snapshot(snapshot).await
+        }
+
+        async fn publish_private_snapshot_no_replace(
+            &self,
+            snapshot: &PrivateSnapshot,
+            destination: &str,
+            expected_seal: &FileSeal,
+        ) -> anyhow::Result<()> {
+            self.inner
+                .publish_private_snapshot_no_replace(snapshot, destination, expected_seal)
+                .await
+        }
+
+        async fn remove_private_snapshot(
+            &self,
+            snapshot: &PrivateSnapshot,
+        ) -> anyhow::Result<()> {
+            self.inner.remove_private_snapshot(snapshot).await
+        }
+
+        async fn regular_file_exists_no_follow(&self, path: &Path) -> anyhow::Result<bool> {
+            self.inner.regular_file_exists_no_follow(path).await
+        }
+
+        async fn remove_regular_no_follow(&self, path: &Path) -> anyhow::Result<()> {
+            self.inner.remove_regular_no_follow(path).await
+        }
+
+        async fn discard_staged(&self, staged: &StagedFile) -> anyhow::Result<()> {
+            self.inner.discard_staged(staged).await
+        }
+
+        async fn publish_staged_no_replace(
+            &self,
+            staged: &StagedFile,
+            destination: &str,
+        ) -> anyhow::Result<()> {
+            self.inner
+                .publish_staged_no_replace(staged, destination)
+                .await
+        }
+
+        async fn restore_staged(&self, staged: &StagedFile) -> anyhow::Result<()> {
+            self.inner.restore_staged(staged).await
+        }
+
+        async fn restore(&self, staged_path: &str, original_path: &str) -> anyhow::Result<()> {
+            self.inner.restore(staged_path, original_path).await
+        }
+
+        async fn get(&self, path: &str) -> anyhow::Result<StoreObject> {
+            self.inner.get(path).await
+        }
+
+        async fn delete(&self, path: &str) -> anyhow::Result<()> {
+            self.inner.delete(path).await
+        }
+
+        async fn remove_empty_dir(&self, path: &Path) -> anyhow::Result<()> {
+            self.inner.remove_empty_dir(path).await
+        }
+    }
 
     impl TestDir {
         fn new(name: &str) -> Self {
@@ -191,6 +304,36 @@ mod tests {
             .expect("new book should be queued")
             .expect("scanner sender should stay open");
         let LocalMessage::Media(MediaEvent::MediaAvailable(event)) = message else {
+            panic!("expected MediaAvailable event");
+        };
+        assert_eq!(event.full_path, book_path);
+        assert_eq!(event.search, None);
+    }
+
+    #[tokio::test]
+    async fn queues_book_from_non_thumbnail_hidden_collection() {
+        let root = TestDir::new("hidden-collection");
+        let book_path = root
+            .path()
+            .join(".archive")
+            .join(".thumbnails")
+            .join("History.pdf");
+        tokio::fs::create_dir_all(book_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&book_path, b"pdf").await.unwrap();
+
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let storer: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let (sender, mut receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository, sender, root.path());
+
+        checker.check_book_information().await.unwrap();
+
+        let LocalMessage::Media(MediaEvent::MediaAvailable(event)) = receiver
+            .try_recv()
+            .expect("book in a non-thumbnail hidden collection should be queued")
+        else {
             panic!("expected MediaAvailable event");
         };
         assert_eq!(event.full_path, book_path);
@@ -315,5 +458,37 @@ mod tests {
         let books = repository.list_all_books().await.unwrap();
         assert_eq!(books.len(), 1);
         assert_eq!(books[0].checksum, 201);
+    }
+
+    #[tokio::test]
+    async fn nested_list_failure_does_not_delete_orphan_rows() {
+        let root = TestDir::new("nested-list-failure");
+        let collection_dir = root.path().join("broken");
+        tokio::fs::create_dir_all(&collection_dir).await.unwrap();
+
+        let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+        let missing_path = collection_dir.join("missing.pdf");
+        let mut orphan = BookDetails::new(
+            "missing.pdf".to_string(),
+            "broken".to_string(),
+            &missing_path,
+            BookFormat::Pdf,
+        );
+        orphan.checksum = 301;
+        orphan.state = BookState::Ready;
+        repository.save_book(&orphan).await.unwrap();
+
+        let inner: FileStorer = Arc::new(FileSystemStore::new(root.path().to_str().unwrap()));
+        let storer: FileStorer = Arc::new(FailingNestedListStore {
+            inner,
+            failing_collection: "broken".to_string(),
+        });
+        let (sender, _receiver) = mpsc::channel(8);
+        let checker = BookCheck::new_with_root(storer, repository.clone(), sender, root.path());
+
+        let error = checker.check_book_information().await.unwrap_err();
+
+        assert!(error.to_string().contains("forced nested list failure"));
+        assert_eq!(repository.retrieve_book(301).await.unwrap().file_name, "missing.pdf");
     }
 }

--- a/src/domain/services/book_metadata.rs
+++ b/src/domain/services/book_metadata.rs
@@ -4126,6 +4126,17 @@ mod tests {
             self.inner.delete_book(checksum).await
         }
 
+        async fn delete_book_if_path_matches(
+            &self,
+            checksum: i64,
+            collection: &str,
+            file_name: &str,
+        ) -> Result<u64, sqlx::Error> {
+            self.inner
+                .delete_book_if_path_matches(checksum, collection, file_name)
+                .await
+        }
+
         async fn save_video(&self, details: &VideoDetails) -> Result<i64, sqlx::Error> {
             self.inner.save_video(details).await
         }

--- a/src/domain/services/book_path_lease.rs
+++ b/src/domain/services/book_path_lease.rs
@@ -1,0 +1,140 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+use tokio::sync::Notify;
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum LeaseState {
+    Processing,
+    Reconciling,
+}
+
+#[derive(Clone, Default)]
+pub struct BookPathLeaseCoordinator {
+    inner: Arc<BookPathLeaseState>,
+}
+
+#[derive(Default)]
+struct BookPathLeaseState {
+    states: Mutex<HashMap<PathBuf, LeaseState>>,
+    changed: Notify,
+}
+
+impl BookPathLeaseCoordinator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn acquire_processing(&self, path: &Path) -> BookPathLease {
+        loop {
+            let changed = self.inner.changed.notified();
+            let acquired = {
+                let mut states = self
+                    .inner
+                    .states
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if states.contains_key(path) {
+                    false
+                } else {
+                    states.insert(path.to_path_buf(), LeaseState::Processing);
+                    true
+                }
+            };
+            if acquired {
+                return BookPathLease {
+                    inner: self.inner.clone(),
+                    path: path.to_path_buf(),
+                    state: LeaseState::Processing,
+                };
+            }
+            changed.await;
+        }
+    }
+
+    pub fn try_acquire_reconciling(&self, path: &Path) -> Option<BookPathLease> {
+        let mut states = self
+            .inner
+            .states
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if states.contains_key(path) {
+            return None;
+        }
+        states.insert(path.to_path_buf(), LeaseState::Reconciling);
+        Some(BookPathLease {
+            inner: self.inner.clone(),
+            path: path.to_path_buf(),
+            state: LeaseState::Reconciling,
+        })
+    }
+}
+
+pub struct BookPathLease {
+    inner: Arc<BookPathLeaseState>,
+    path: PathBuf,
+    state: LeaseState,
+}
+
+impl Drop for BookPathLease {
+    fn drop(&mut self) {
+        {
+            let mut states = self
+                .inner
+                .states
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if states.get(&self.path) == Some(&self.state) {
+                states.remove(&self.path);
+            }
+        }
+        self.inner.changed.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::BookPathLeaseCoordinator;
+    use tokio::{sync::oneshot, time::Duration};
+
+    #[tokio::test]
+    async fn processing_lease_makes_reconciliation_unavailable() {
+        let coordinator = BookPathLeaseCoordinator::new();
+        let path = Path::new("library/collection/book.epub");
+
+        let processing = coordinator.acquire_processing(path).await;
+
+        assert!(coordinator.try_acquire_reconciling(path).is_none());
+        drop(processing);
+        assert!(coordinator.try_acquire_reconciling(path).is_some());
+    }
+
+    #[tokio::test]
+    async fn reconciling_lease_makes_processing_wait_until_release() {
+        let coordinator = BookPathLeaseCoordinator::new();
+        let path = Path::new("library/collection/book.epub");
+        let reconciling = coordinator.try_acquire_reconciling(path).unwrap();
+        let waiting_coordinator = coordinator.clone();
+        let waiting_path = path.to_path_buf();
+        let (acquired_tx, mut acquired_rx) = oneshot::channel();
+        let waiter = tokio::spawn(async move {
+            let processing = waiting_coordinator.acquire_processing(&waiting_path).await;
+            acquired_tx.send(()).unwrap();
+            processing
+        });
+
+        assert!(tokio::time::timeout(Duration::from_millis(25), &mut acquired_rx)
+            .await
+            .is_err());
+        drop(reconciling);
+        tokio::time::timeout(Duration::from_secs(1), &mut acquired_rx)
+            .await
+            .expect("processing should acquire after reconciliation releases")
+            .unwrap();
+        drop(waiter.await.unwrap());
+    }
+}

--- a/src/domain/services/mod.rs
+++ b/src/domain/services/mod.rs
@@ -1,6 +1,7 @@
 mod video_metadata;
 mod book_metadata;
 mod media_check;
+mod book_check;
 mod download_monitor;
 mod history;
 mod encoding;
@@ -16,6 +17,7 @@ pub use book_metadata::{
 };
 pub(crate) use book_metadata::generate_book_metadata_with_cancellation;
 pub use media_check::MediaCheck;
+pub use book_check::BookCheck;
 pub use download_monitor::DownloadMonitor;
 pub use history::HistoryService;
 pub use encoding::{convert_to_mp4, extract_subtitles, re_encode, should_re_encode, re_encode_video, CodecArgs, AlreadyEncodedError};

--- a/src/domain/services/mod.rs
+++ b/src/domain/services/mod.rs
@@ -2,6 +2,7 @@ mod video_metadata;
 mod book_metadata;
 mod media_check;
 mod book_check;
+mod book_path_lease;
 mod download_monitor;
 mod history;
 mod encoding;
@@ -18,6 +19,7 @@ pub use book_metadata::{
 pub(crate) use book_metadata::generate_book_metadata_with_cancellation;
 pub use media_check::MediaCheck;
 pub use book_check::BookCheck;
+pub use book_path_lease::BookPathLeaseCoordinator;
 pub use download_monitor::DownloadMonitor;
 pub use history::HistoryService;
 pub use encoding::{convert_to_mp4, extract_subtitles, re_encode, should_re_encode, re_encode_video, CodecArgs, AlreadyEncodedError};

--- a/src/domain/traits.rs
+++ b/src/domain/traits.rs
@@ -47,6 +47,15 @@ pub trait MediaChecker: Send + Sync {
 
 pub type Checker = Arc<dyn MediaChecker>;
 
+/// Provides a separate boundary for checking book files and metadata state.
+#[automock]
+#[async_trait]
+pub trait BookChecker: Send + Sync {
+    async fn check_book_information(&self) -> anyhow::Result<()>;
+}
+
+pub type BookCheckerHandle = Arc<dyn BookChecker>;
+
 
 /// Provides an interface to observe the progress of a download
 #[automock]

--- a/src/domain/traits.rs
+++ b/src/domain/traits.rs
@@ -247,6 +247,12 @@ pub trait Databaser: Sync + Send {
     async fn list_all_books(&self) -> Result<Vec<BookDetails>, sqlx::Error>;
     async fn retrieve_book(&self, checksum: i64) -> Result<BookDetails, sqlx::Error>;
     async fn delete_book(&self, checksum: i64) -> Result<u64, sqlx::Error>;
+    async fn delete_book_if_path_matches(
+        &self,
+        checksum: i64,
+        collection: &str,
+        file_name: &str,
+    ) -> Result<u64, sqlx::Error>;
     async fn save_video(&self, details: &VideoDetails) -> Result<i64, sqlx::Error>;
     async fn list_collection(&self, collection: &str)  -> Result<Vec<String>, sqlx::Error>;
     async fn list_videos(&self, collection: &str)  -> Result<Vec<VideoDetails>, sqlx::Error>;

--- a/src/domain/traits.rs
+++ b/src/domain/traits.rs
@@ -168,6 +168,12 @@ impl PrivateSnapshot {
 pub trait FileStore: Sync + Send {
     async fn create_folder(&self, path: &Path) -> anyhow::Result<()>;
     async fn list_folder(&self, path: &str) -> anyhow::Result<(Vec<String>, Vec<String>)>;
+    async fn list_folder_no_follow(
+        &self,
+        path: &str,
+    ) -> anyhow::Result<(Vec<String>, Vec<String>)> {
+        self.list_folder(path).await
+    }
     async fn ensure_path_exists(&self, path: &str) -> anyhow::Result<()>;
     async fn rename(&self, old_path: &str, new_path: &str) -> anyhow::Result<()>;
     async fn rename_no_replace(&self, old_path: &str, new_path: &str) -> anyhow::Result<()>;

--- a/src/entrypoints/context.rs
+++ b/src/entrypoints/context.rs
@@ -12,9 +12,9 @@ use crate::domain::messagebus::{
     LocalMessageExchange, LocalMessageExchangeError, MessageExchange, MessageFilter,
 };
 use crate::domain::messages::{LocalMessageReceiver, LocalMessageSender};
-use crate::domain::services::MediaCheck;
+use crate::domain::services::{BookCheck, MediaCheck};
 use crate::domain::traits::FileStorer;
-use crate::domain::traits::{Checker, ProcessSpawner, Repository, Storer};
+use crate::domain::traits::{BookCheckerHandle, Checker, ProcessSpawner, Repository, Storer};
 use crate::domain::SearchEngineType;
 use crate::services::{
     BookStore, MediaStore, PirateClient, SearchEngine, SearchService, SharingService, TaskManager,
@@ -25,6 +25,7 @@ use crate::services::{
 pub struct Context {
     store: Storer,
     checker: Checker,
+    book_checker: BookCheckerHandle,
     search: SearchService,
     messenger: MessageExchange,
     task_manager: Arc<TaskManager>,
@@ -43,6 +44,7 @@ impl Context {
         task_manager: Arc<TaskManager>,
         repository: Repository,
         checker: Checker,
+        book_checker: BookCheckerHandle,
         local_message_exchange: LocalMessageExchange,
         book_store: Arc<BookStore>,
         book_file_storer: FileStorer,
@@ -51,6 +53,7 @@ impl Context {
         Context {
             store,
             checker,
+            book_checker,
             search,
             messenger,
             task_manager,
@@ -93,6 +96,10 @@ impl Context {
 
     pub fn get_checker(&self) -> Checker {
         self.checker.clone()
+    }
+
+    pub fn get_book_checker(&self) -> BookCheckerHandle {
+        self.book_checker.clone()
     }
 
     pub fn get_storer(&self) -> Storer {
@@ -192,6 +199,11 @@ pub async fn create_context() -> anyhow::Result<Context> {
         repository.clone(),
         local_message_exchange.new_sender(),
     ));
+    let book_checker = Arc::new(BookCheck::new(
+        book_file_storer.clone(),
+        repository.clone(),
+        local_message_exchange.new_sender(),
+    ));
 
     let sharing = Arc::new(SharingService::new(
         Arc::new(TelegramBot::new(&get_telegram_chat_id(), &get_telegram_token())),
@@ -206,6 +218,7 @@ pub async fn create_context() -> anyhow::Result<Context> {
         task_manager,
         repository,
         checker,
+        book_checker,
         local_message_exchange,
         book_store,
         book_file_storer,
@@ -221,7 +234,10 @@ mod tests {
         adaptors::{FileSystemStore, SqlRepository},
         domain::{
             messagebus::{LocalMessageExchange, MessageExchange, MessageFilter},
-            traits::{FileStorer, MockMediaChecker, MockMediaStorer, Repository, Storer},
+            traits::{
+                BookCheckerHandle, FileStorer, MockBookChecker, MockMediaChecker, MockMediaStorer,
+                Repository, Storer,
+            },
             NoSpawner,
         },
         services::{BookStore, SearchService, TaskManager},
@@ -244,6 +260,7 @@ mod tests {
         );
         let media_store: Storer = Arc::new(MockMediaStorer::new());
         let checker = Arc::new(MockMediaChecker::new());
+        let book_checker: BookCheckerHandle = Arc::new(MockBookChecker::new());
         let book_files: FileStorer = Arc::new(FileSystemStore::new("/tmp/context-books"));
         let thumbnail_files: FileStorer =
             Arc::new(FileSystemStore::new("/tmp/context-book-thumbnails"));
@@ -262,6 +279,7 @@ mod tests {
             task_manager,
             repository,
             checker,
+            book_checker.clone(),
             local_message_exchange,
             book_store.clone(),
             book_files.clone(),
@@ -270,5 +288,6 @@ mod tests {
 
         assert!(Arc::ptr_eq(&context.get_book_store(), &book_store));
         assert!(Arc::ptr_eq(&context.get_book_file_storer(), &book_files));
+        assert!(Arc::ptr_eq(&context.get_book_checker(), &book_checker));
     }
 }

--- a/src/entrypoints/context.rs
+++ b/src/entrypoints/context.rs
@@ -12,7 +12,7 @@ use crate::domain::messagebus::{
     LocalMessageExchange, LocalMessageExchangeError, MessageExchange, MessageFilter,
 };
 use crate::domain::messages::{LocalMessageReceiver, LocalMessageSender};
-use crate::domain::services::{BookCheck, MediaCheck};
+use crate::domain::services::{BookCheck, BookPathLeaseCoordinator, MediaCheck};
 use crate::domain::traits::FileStorer;
 use crate::domain::traits::{BookCheckerHandle, Checker, ProcessSpawner, Repository, Storer};
 use crate::domain::SearchEngineType;
@@ -33,6 +33,7 @@ pub struct Context {
     local_message_exchange: LocalMessageExchange,
     book_store: Arc<BookStore>,
     book_file_storer: FileStorer,
+    book_path_leases: BookPathLeaseCoordinator,
     sharing: Option<Arc<SharingService>>,
 }
 
@@ -50,6 +51,36 @@ impl Context {
         book_file_storer: FileStorer,
         sharing: Option<Arc<SharingService>>,
     ) -> Context {
+        Self::new_with_book_path_leases(
+            store,
+            search,
+            messenger,
+            task_manager,
+            repository,
+            checker,
+            book_checker,
+            local_message_exchange,
+            book_store,
+            book_file_storer,
+            sharing,
+            BookPathLeaseCoordinator::new(),
+        )
+    }
+
+    pub fn new_with_book_path_leases(
+        store: Storer,
+        search: SearchService,
+        messenger: MessageExchange,
+        task_manager: Arc<TaskManager>,
+        repository: Repository,
+        checker: Checker,
+        book_checker: BookCheckerHandle,
+        local_message_exchange: LocalMessageExchange,
+        book_store: Arc<BookStore>,
+        book_file_storer: FileStorer,
+        sharing: Option<Arc<SharingService>>,
+        book_path_leases: BookPathLeaseCoordinator,
+    ) -> Context {
         Context {
             store,
             checker,
@@ -61,6 +92,7 @@ impl Context {
             local_message_exchange,
             book_store,
             book_file_storer,
+            book_path_leases,
             sharing,
         }
     }
@@ -128,6 +160,10 @@ impl Context {
 
     pub fn get_book_file_storer(&self) -> FileStorer {
         self.book_file_storer.clone()
+    }
+
+    pub fn get_book_path_leases(&self) -> BookPathLeaseCoordinator {
+        self.book_path_leases.clone()
     }
 }
 
@@ -199,10 +235,12 @@ pub async fn create_context() -> anyhow::Result<Context> {
         repository.clone(),
         local_message_exchange.new_sender(),
     ));
-    let book_checker = Arc::new(BookCheck::new(
+    let book_path_leases = BookPathLeaseCoordinator::new();
+    let book_checker = Arc::new(BookCheck::new_with_leases(
         book_file_storer.clone(),
         repository.clone(),
         local_message_exchange.new_sender(),
+        book_path_leases.clone(),
     ));
 
     let sharing = Arc::new(SharingService::new(
@@ -211,7 +249,7 @@ pub async fn create_context() -> anyhow::Result<Context> {
         spawner.clone(),
     ));
 
-    Ok(Context::new(
+    Ok(Context::new_with_book_path_leases(
         Arc::new(MediaStore::new(file_storer, repository.clone())),
         search_service,
         messenger,
@@ -223,6 +261,7 @@ pub async fn create_context() -> anyhow::Result<Context> {
         book_store,
         book_file_storer,
         Some(sharing),
+        book_path_leases,
     ))
 }
 
@@ -234,6 +273,7 @@ mod tests {
         adaptors::{FileSystemStore, SqlRepository},
         domain::{
             messagebus::{LocalMessageExchange, MessageExchange, MessageFilter},
+            services::BookPathLeaseCoordinator,
             traits::{
                 BookCheckerHandle, FileStorer, MockBookChecker, MockMediaChecker, MockMediaStorer,
                 Repository, Storer,
@@ -271,8 +311,9 @@ mod tests {
             Path::new("/tmp/context-books"),
             Path::new("/tmp/context-book-thumbnails"),
         ));
+        let book_path_leases = BookPathLeaseCoordinator::new();
 
-        let context = Context::new(
+        let context = Context::new_with_book_path_leases(
             media_store,
             search,
             messenger,
@@ -284,10 +325,17 @@ mod tests {
             book_store.clone(),
             book_files.clone(),
             None,
+            book_path_leases.clone(),
         );
 
         assert!(Arc::ptr_eq(&context.get_book_store(), &book_store));
         assert!(Arc::ptr_eq(&context.get_book_file_storer(), &book_files));
         assert!(Arc::ptr_eq(&context.get_book_checker(), &book_checker));
+        let leased_path = Path::new("/tmp/context-books/leased.epub");
+        let _processing = book_path_leases.acquire_processing(leased_path).await;
+        assert!(context
+            .get_book_path_leases()
+            .try_acquire_reconciling(leased_path)
+            .is_none());
     }
 }

--- a/src/entrypoints/tvserver.rs
+++ b/src/entrypoints/tvserver.rs
@@ -25,7 +25,7 @@ impl TVServer {
             context.get_local_sender(),
         );
 
-        let metadata_manager = MetaDataManager::consume(
+        let metadata_manager = MetaDataManager::consume_with_leases(
             context.get_repository(),
             context.get_store(),
             context.get_book_file_storer(),
@@ -35,6 +35,7 @@ impl TVServer {
                 .map_err(|e| anyhow::anyhow!("failed to listen for messages: {}", e))?,
             context.get_local_sender(),
             context.get_spawner(),
+            context.get_book_path_leases(),
         );
 
         let hs = HistoryService::new(context.get_repository(), context.get_local_sender());

--- a/src/entrypoints/tvserver.rs
+++ b/src/entrypoints/tvserver.rs
@@ -19,6 +19,7 @@ impl TVServer {
 
         let monitor_handle = Monitor::start(
             context.get_checker(),
+            context.get_book_checker(),
             context.get_task_manager(),
             context.get_store(),
             context.get_local_sender(),

--- a/src/services/monitor.rs
+++ b/src/services/monitor.rs
@@ -1,5 +1,5 @@
 use crate::domain::messages::{LocalMessage, LocalMessageSender};
-use crate::domain::traits::{Checker, ProcessSpawner, Storer};
+use crate::domain::traits::{BookCheckerHandle, Checker, ProcessSpawner, Storer};
 use crate::services::TaskManager;
 use std::sync::Arc;
 use tokio::task::{self, JoinHandle};
@@ -7,6 +7,7 @@ use tokio::time::{sleep, Duration};
 
 pub struct Monitor {
     checker: Checker,
+    book_checker: BookCheckerHandle,
     task_manager: Arc<TaskManager>,
     store: Storer,
     sender: LocalMessageSender,
@@ -15,6 +16,7 @@ pub struct Monitor {
 impl Monitor {
     pub fn start(
         checker: Checker,
+        book_checker: BookCheckerHandle,
         task_manager: Arc<TaskManager>,
         store: Storer,
         sender: LocalMessageSender,
@@ -26,6 +28,7 @@ impl Monitor {
             tracing::info!("starting download monitor");
             let monitor = Self {
                 checker,
+                book_checker,
                 task_manager,
                 store,
                 sender,
@@ -34,25 +37,7 @@ impl Monitor {
             let mut counter: i64 = 0;
             let mut had_tasks = false;
             loop {
-                // Check video information every ~5 minutes when idle (30s when tasks active)
-                if counter % 10 == 0 {
-                    monitor.task_manager.cleanup(&monitor.store).await;
-
-                    if let Err(err) = &monitor.checker.check_video_information().await {
-                        tracing::error!("error checking video info: {}", err);
-                    }
-                }
-
-                let current_state = monitor.task_manager.get_current_state().await;
-                let has_tasks = !current_state.is_empty();
-
-                // Broadcast when tasks exist, or once when transitioning to empty
-                // so clients clear their task UI
-                if has_tasks || had_tasks {
-                    if let Err(e) = monitor.sender.send(LocalMessage::Task(current_state)).await {
-                        tracing::error!("could not send task state: {}", e.to_string());
-                    }
-                }
+                let has_tasks = monitor.run_cycle(counter, had_tasks).await;
                 had_tasks = has_tasks;
 
                 // Back off when idle: 5s with no tasks, 3s with active tasks
@@ -62,5 +47,78 @@ impl Monitor {
             }
         })
     }
+
+    async fn run_cycle(&self, counter: i64, had_tasks: bool) -> bool {
+        // Check media information every ~5 minutes when idle (30s when tasks active)
+        if counter % 10 == 0 {
+            self.task_manager.cleanup(&self.store).await;
+
+            if let Err(error) = self.checker.check_video_information().await {
+                tracing::error!("error checking video info: {error}");
+            }
+            if let Err(error) = self.book_checker.check_book_information().await {
+                tracing::error!("error checking book info: {error}");
+            }
+        }
+
+        let current_state = self.task_manager.get_current_state().await;
+        let has_tasks = !current_state.is_empty();
+
+        // Broadcast when tasks exist, or once when transitioning to empty
+        // so clients clear their task UI.
+        if has_tasks || had_tasks {
+            if let Err(error) = self.sender.send(LocalMessage::Task(current_state)).await {
+                tracing::error!("could not send task state: {error}");
+            }
+        }
+
+        has_tasks
+    }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::domain::{
+        messages::LocalMessage,
+        traits::{MockBookChecker, MockMediaChecker, MockMediaStorer, Storer},
+        NoSpawner,
+    };
+    use tokio::sync::mpsc;
+
+    use super::{Monitor, TaskManager};
+
+    #[tokio::test]
+    async fn book_scan_failure_does_not_stop_broadcast_or_video_scan() {
+        let mut video_checker = MockMediaChecker::new();
+        video_checker
+            .expect_check_video_information()
+            .times(1)
+            .returning(|| Ok(()));
+        let mut book_checker = MockBookChecker::new();
+        book_checker
+            .expect_check_book_information()
+            .times(1)
+            .returning(|| Err(anyhow::anyhow!("book scan failed")));
+        let store: Storer = Arc::new(MockMediaStorer::new());
+        let task_manager = Arc::new(TaskManager::new(Arc::new(NoSpawner::new())));
+        let (sender, mut receiver) = mpsc::channel(4);
+        let monitor = Monitor {
+            checker: Arc::new(video_checker),
+            book_checker: Arc::new(book_checker),
+            task_manager,
+            store,
+            sender,
+        };
+
+        let has_tasks = monitor.run_cycle(0, true).await;
+
+        assert!(!has_tasks);
+        let message = receiver.recv().await.expect("task state should be broadcast");
+        let LocalMessage::Task(state) = message else {
+            panic!("expected task state message");
+        };
+        assert!(state.is_empty());
+    }
+}

--- a/src/services/video_information.rs
+++ b/src/services/video_information.rs
@@ -1,6 +1,8 @@
 use crate::domain::algorithm::{classify_media_kind, MediaKind};
 use crate::domain::messages::{LocalMessage, LocalMessageReceiver, LocalMessageSender, MediaEvent};
-use crate::domain::services::{generate_book_metadata_with_cancellation, generate_video_metadatas};
+use crate::domain::services::{
+    generate_book_metadata_with_cancellation, generate_video_metadatas, BookPathLeaseCoordinator,
+};
 use crate::domain::traits::{FileStorer, ProcessSpawner, Repository, Storer};
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
@@ -89,6 +91,7 @@ pub struct MetaDataManager {
     receiver: LocalMessageReceiver,
     _sender: LocalMessageSender,
     processing_paths: Arc<StdMutex<HashSet<PathBuf>>>,
+    book_path_leases: BookPathLeaseCoordinator,
     spawner: Arc<dyn ProcessSpawner>,
     processor: Arc<dyn MetadataProcessor>,
     workers: JoinSet<()>,
@@ -159,6 +162,7 @@ impl Drop for MetaDataManagerHandle {
 }
 
 impl MetaDataManager {
+    #[cfg(test)]
     fn new_with_processor(
         repo: Repository,
         storer: Storer,
@@ -169,6 +173,30 @@ impl MetaDataManager {
         processor: Arc<dyn MetadataProcessor>,
         cancellation: CancellationToken,
     ) -> Self {
+        Self::new_with_processor_and_leases(
+            repo,
+            storer,
+            book_storer,
+            receiver,
+            sender,
+            spawner,
+            processor,
+            cancellation,
+            BookPathLeaseCoordinator::new(),
+        )
+    }
+
+    fn new_with_processor_and_leases(
+        repo: Repository,
+        storer: Storer,
+        book_storer: FileStorer,
+        receiver: LocalMessageReceiver,
+        sender: LocalMessageSender,
+        spawner: Arc<dyn ProcessSpawner>,
+        processor: Arc<dyn MetadataProcessor>,
+        cancellation: CancellationToken,
+        book_path_leases: BookPathLeaseCoordinator,
+    ) -> Self {
         Self {
             repo,
             storer,
@@ -176,6 +204,7 @@ impl MetaDataManager {
             receiver,
             _sender: sender,
             processing_paths: Arc::new(StdMutex::new(HashSet::new())),
+            book_path_leases,
             spawner,
             processor,
             workers: JoinSet::new(),
@@ -202,6 +231,27 @@ impl MetaDataManager {
         )
     }
 
+    pub fn consume_with_leases(
+        repo: Repository,
+        storer: Storer,
+        book_storer: FileStorer,
+        receiver: LocalMessageReceiver,
+        sender: LocalMessageSender,
+        spawner: Arc<dyn ProcessSpawner>,
+        book_path_leases: BookPathLeaseCoordinator,
+    ) -> MetaDataManagerHandle {
+        Self::consume_with_processor_and_leases(
+            repo,
+            storer,
+            book_storer,
+            receiver,
+            sender,
+            spawner,
+            Arc::new(ProductionMetadataProcessor),
+            book_path_leases,
+        )
+    }
+
     fn consume_with_processor(
         repo: Repository,
         storer: Storer,
@@ -211,10 +261,32 @@ impl MetaDataManager {
         spawner: Arc<dyn ProcessSpawner>,
         processor: Arc<dyn MetadataProcessor>,
     ) -> MetaDataManagerHandle {
+        Self::consume_with_processor_and_leases(
+            repo,
+            storer,
+            book_storer,
+            receiver,
+            sender,
+            spawner,
+            processor,
+            BookPathLeaseCoordinator::new(),
+        )
+    }
+
+    fn consume_with_processor_and_leases(
+        repo: Repository,
+        storer: Storer,
+        book_storer: FileStorer,
+        receiver: LocalMessageReceiver,
+        sender: LocalMessageSender,
+        spawner: Arc<dyn ProcessSpawner>,
+        processor: Arc<dyn MetadataProcessor>,
+        book_path_leases: BookPathLeaseCoordinator,
+    ) -> MetaDataManagerHandle {
         let cancellation = CancellationToken::new();
         let manager_cancellation = cancellation.clone();
         let task = tokio::spawn(async move {
-            let mut manager = Self::new_with_processor(
+            let mut manager = Self::new_with_processor_and_leases(
                 repo,
                 storer,
                 book_storer,
@@ -223,6 +295,7 @@ impl MetaDataManager {
                 spawner,
                 processor,
                 manager_cancellation,
+                book_path_leases,
             );
             manager.event_loop().await;
             eprintln!("local event loop exiting");
@@ -293,6 +366,7 @@ impl MetaDataManager {
                 let semaphore = WORKER_SEMAPHORE.clone();
                 let spawner = self.spawner.clone();
                 let processor = self.processor.clone();
+                let book_path_leases = self.book_path_leases.clone();
                 let cancellation = self.cancellation.clone();
                 self.workers.spawn(async move {
                     let _path_guard = path_guard;
@@ -324,6 +398,7 @@ impl MetaDataManager {
                             }
                         }
                         MediaKind::Book => {
+                            let _processing = book_path_leases.acquire_processing(&full_path).await;
                             if let Err(err) = processor
                                 .process_book(
                                     full_path,
@@ -366,6 +441,7 @@ mod tests {
         adaptors::{FileSystemStore, SqlRepository},
         domain::{
             messagebus::{LocalMessageExchange, MessageFilter},
+            services::BookPathLeaseCoordinator,
             traits::{MockMediaStorer, Repository},
             NoSpawner,
         },
@@ -413,6 +489,39 @@ mod tests {
     struct CancellationAwareProcessor {
         started: Notify,
         observed: AtomicUsize,
+    }
+
+    struct FailingBookProcessor {
+        started: Notify,
+        releases: Semaphore,
+    }
+
+    #[async_trait]
+    impl MetadataProcessor for FailingBookProcessor {
+        async fn process_video(
+            &self,
+            _path: PathBuf,
+            _storer: Storer,
+            _repo: Repository,
+            _search: Option<String>,
+            _spawner: Arc<dyn ProcessSpawner>,
+            _cancellation: CancellationToken,
+        ) -> Result<(), String> {
+            unreachable!("lease lifecycle test uses a book path")
+        }
+
+        async fn process_book(
+            &self,
+            _path: PathBuf,
+            _storer: FileStorer,
+            _repo: Repository,
+            _search: Option<String>,
+            _cancellation: CancellationToken,
+        ) -> Result<(), String> {
+            self.started.notify_one();
+            self.releases.acquire().await.unwrap().forget();
+            Err("forced book processing failure".to_string())
+        }
     }
 
     #[async_trait]
@@ -540,6 +649,33 @@ mod tests {
         )
     }
 
+    async fn manager_with_processor_and_leases(
+        processor: Arc<dyn MetadataProcessor>,
+        leases: BookPathLeaseCoordinator,
+    ) -> MetaDataManager {
+        let exchange = LocalMessageExchange::new();
+        let receiver = exchange
+            .listen_for_messages(MessageFilter::All)
+            .await
+            .unwrap();
+        MetaDataManager::new_with_processor_and_leases(
+            Arc::new(SqlRepository::new(":memory:", None).await.unwrap()),
+            Arc::new(MockMediaStorer::new()),
+            Arc::new(FileSystemStore::new(
+                std::env::temp_dir()
+                    .join("tvserver-routing-lease-test-books")
+                    .to_str()
+                    .unwrap(),
+            )),
+            receiver,
+            exchange.new_sender(),
+            Arc::new(NoSpawner::new()),
+            processor,
+            CancellationToken::new(),
+            leases,
+        )
+    }
+
     async fn dispatch_and_wait(
         manager: &mut MetaDataManager,
         processor: &RecordingProcessor,
@@ -601,6 +737,35 @@ mod tests {
 
         assert_eq!(processor.calls(), [MediaKind::Video]);
         processor.releases.add_permits(1);
+    }
+
+    #[tokio::test]
+    async fn book_worker_holds_processing_lease_until_processor_error_returns() {
+        let processor = Arc::new(FailingBookProcessor {
+            started: Notify::new(),
+            releases: Semaphore::new(0),
+        });
+        let leases = BookPathLeaseCoordinator::new();
+        let mut manager =
+            manager_with_processor_and_leases(processor.clone(), leases.clone()).await;
+        let path = PathBuf::from("library/blocked.epub");
+        let started = processor.started.notified();
+
+        manager
+            .handle_media_event(MediaEvent::new_media(&path, None))
+            .await;
+        tokio::time::timeout(std::time::Duration::from_secs(2), started)
+            .await
+            .expect("book processor should start");
+
+        assert!(leases.try_acquire_reconciling(&path).is_none());
+        processor.releases.add_permits(1);
+        tokio::time::timeout(std::time::Duration::from_secs(2), manager.workers.join_next())
+            .await
+            .expect("book worker should finish after processor error")
+            .expect("book worker should be present")
+            .expect("book worker should not panic");
+        assert!(leases.try_acquire_reconciling(&path).is_some());
     }
 
     #[tokio::test]

--- a/tests/common/context.rs
+++ b/tests/common/context.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use app_lib::adaptors::FileSystemStore;
 use app_lib::domain::messagebus::{LocalMessageExchange, MessageExchange, MessageFilter};
-use app_lib::domain::traits::{Checker, FileStorer, Repository, Storer};
+use app_lib::domain::traits::{Checker, FileStorer, MockBookChecker, Repository, Storer};
 use app_lib::entrypoints::Context;
 use app_lib::services::{BookStore, SearchService, TaskManager};
 use std::{path::Path, sync::Arc};
@@ -52,6 +52,7 @@ pub async fn get_context_with_book_services(
         task_manager,
         repository,
         checker,
+        Arc::new(MockBookChecker::new()),
         local_message_exchange,
         book_store,
         book_file_storer,

--- a/tests/play_test.rs
+++ b/tests/play_test.rs
@@ -5,11 +5,13 @@ use anyhow::Result;
 use app_lib::domain::config::MOVIE_DIR;
 use app_lib::domain::messagebus::{LocalMessageExchange, MessageExchange, MessageFilter};
 use app_lib::domain::messages::PlayRequest;
+use app_lib::domain::traits::MockBookChecker;
 use app_lib::{domain::messages::Response, entrypoints};
 use common::get_checker;
 use std::env;
 use std::net::SocketAddr;
 use std::str::FromStr;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn test_remote_play() -> Result<()> {
@@ -40,6 +42,7 @@ async fn test_remote_play() -> Result<()> {
         get_task_manager(),
         repository,
         get_checker(),
+        Arc::new(MockBookChecker::new()),
         local_exchange,
         book_store,
         book_file_storer,


### PR DESCRIPTION
## Summary

- add an independent recursive idle scanner for PDF and EPUB files under `BOOK_DIR`
- queue new and retryable books through the existing media event pipeline
- reconcile orphaned book records safely while preserving video scanning and task broadcasts
- harden traversal and reconciliation against symlinks, partial scans, relocations, and concurrent ingestion races

## Validation

- `cargo test --no-default-features --features webserver` — 286 passed, 0 failed, 4 ignored
- `cargo check`
- `git diff --check origin/spec/ebook-support..HEAD`
- independent code review — no critical, important, or minor findings

Closes #44