### PR TITLE
Add OpenAPI REST contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [build-dependencies]
 tauri-build = { version = "2.6.3", features = [], optional = true }
 
+[dev-dependencies]
+oas3 = { version = "0.22", features = ["yaml-spec"] }
+roas = { version = "=0.17.2", default-features = false, features = ["v3_1"] }
+serde_yaml = "0.9"
+
 [profile.release]
 codegen-units = 1 # Allows LLVM to perform better optimization.
 lto = true # Enables link-time-optimizations.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -50,8 +50,16 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLargeTextResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeTextResponse'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityTextResponse'
         '500':
           $ref: '#/components/responses/ErrorResponse'
   /api/tasks/{type}/{path}:
@@ -75,6 +83,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '500':
@@ -93,8 +103,16 @@ paths:
       responses:
         '200':
           description: Messages were logged; the response has no body.
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLargeTextResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeTextResponse'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityTextResponse'
   /api/media:
     get:
       tags: [Media]
@@ -136,6 +154,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MediaItem'
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '404':
           description: Video collection error encoded as a MediaItem Error variant
           content:
@@ -158,6 +178,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '500':
@@ -184,9 +206,15 @@ paths:
         '200':
           $ref: '#/components/responses/SuccessResponse'
         '400':
-          description: The wildcard value is not a valid integer checksum.
+          $ref: '#/components/responses/BadRequestTextResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLargeTextResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeTextResponse'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityTextResponse'
         '500':
           $ref: '#/components/responses/ErrorResponse'
     patch:
@@ -203,6 +231,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '500':
@@ -246,6 +276,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BookCollectionDetails'
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '500':
           description: Collection-shaped error response with errors populated
           content:
@@ -314,14 +346,10 @@ paths:
                 type: integer
                 minimum: 0
           content:
-            application/pdf:
-              schema:
-                type: string
-                contentEncoding: binary
-            application/epub+zip:
-              schema:
-                type: string
-                contentEncoding: binary
+            application/pdf: {}
+            application/epub+zip: {}
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '404':
           description: Missing, unsupported, or rejected path; the response has no body.
         '401':
@@ -350,10 +378,9 @@ paths:
                 type: integer
                 minimum: 0
           content:
-            image/jpeg:
-              schema:
-                type: string
-                contentEncoding: binary
+            image/jpeg: {}
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '404':
           description: Missing, unsupported, or rejected filename; the response has no body.
         '500':
@@ -386,8 +413,16 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLargeTextResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeTextResponse'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityTextResponse'
         '500':
           $ref: '#/components/responses/ErrorResponse'
   /api/remote/play:
@@ -404,8 +439,16 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLargeTextResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeTextResponse'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityTextResponse'
         '500':
           $ref: '#/components/responses/ErrorResponse'
   /api/remote/ws:
@@ -493,29 +536,21 @@ paths:
             type: string
       responses:
         '200':
-          description: Complete video representation; media type depends on the stored file.
-          content:
-            video/*:
-              schema:
-                type: string
-                contentEncoding: binary
-            application/octet-stream:
-              schema:
-                type: string
-                contentEncoding: binary
+          $ref: '#/components/responses/ServeDirOkResponse'
         '206':
-          description: Byte range selected by the static file service.
-          content:
-            video/*:
-              schema:
-                type: string
-                contentEncoding: binary
-            application/octet-stream:
-              schema:
-                type: string
-                contentEncoding: binary
+          $ref: '#/components/responses/ServeDirPartialContentResponse'
+        '304':
+          $ref: '#/components/responses/ServeDirNotModifiedResponse'
+        '307':
+          $ref: '#/components/responses/ServeDirRedirectResponse'
         '404':
           description: File not found
+        '412':
+          $ref: '#/components/responses/ServeDirPreconditionFailedResponse'
+        '416':
+          $ref: '#/components/responses/ServeDirRangeNotSatisfiableResponse'
+        '500':
+          $ref: '#/components/responses/ServeDirInternalErrorResponse'
   /api/stream-audio/{audio_index}/{path}:
     get:
       tags: [Media]
@@ -541,10 +576,9 @@ paths:
         '200':
           description: Remuxed Matroska stream
           content:
-            video/x-matroska:
-              schema:
-                type: string
-                contentEncoding: binary
+            video/x-matroska: {}
+        '400':
+          $ref: '#/components/responses/BadRequestTextResponse'
         '403':
           description: Resolved file is outside the movie directory
           content:
@@ -578,14 +612,21 @@ paths:
             type: string
       responses:
         '200':
-          description: Thumbnail bytes; media type depends on the stored image.
-          content:
-            image/*:
-              schema:
-                type: string
-                contentEncoding: binary
+          $ref: '#/components/responses/ServeDirOkResponse'
+        '206':
+          $ref: '#/components/responses/ServeDirPartialContentResponse'
+        '304':
+          $ref: '#/components/responses/ServeDirNotModifiedResponse'
+        '307':
+          $ref: '#/components/responses/ServeDirRedirectResponse'
         '404':
           description: Thumbnail not found
+        '412':
+          $ref: '#/components/responses/ServeDirPreconditionFailedResponse'
+        '416':
+          $ref: '#/components/responses/ServeDirRangeNotSatisfiableResponse'
+        '500':
+          $ref: '#/components/responses/ServeDirInternalErrorResponse'
 components:
   securitySchemes:
     HttpBasicAuth:
@@ -645,6 +686,92 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/SearchResults'
+    BadRequestTextResponse:
+      description: Axum could not deserialize a path value or the JSON syntax was malformed.
+      content:
+        text/plain:
+          schema:
+            type: string
+    PayloadTooLargeTextResponse:
+      description: The JSON body exceeds Axum's default two-megabyte request-body limit.
+      content:
+        text/plain:
+          schema:
+            type: string
+    UnsupportedMediaTypeTextResponse:
+      description: The request Content-Type is missing or is not JSON.
+      content:
+        text/plain:
+          schema:
+            type: string
+    UnprocessableEntityTextResponse:
+      description: The JSON is valid but does not deserialize into the request type.
+      content:
+        text/plain:
+          schema:
+            type: string
+    ServeDirOkResponse:
+      description: Complete file representation; Content-Type is guessed from the stored file extension.
+      headers:
+        Accept-Ranges:
+          schema:
+            type: string
+            const: bytes
+        Last-Modified:
+          schema:
+            type: string
+        Content-Length:
+          schema:
+            type: integer
+            minimum: 0
+      content:
+        '*/*': {}
+    ServeDirPartialContentResponse:
+      description: One satisfiable byte range selected by the static file service.
+      headers:
+        Accept-Ranges:
+          schema:
+            type: string
+            const: bytes
+        Last-Modified:
+          schema:
+            type: string
+        Content-Length:
+          schema:
+            type: integer
+            minimum: 0
+        Content-Range:
+          schema:
+            type: string
+      content:
+        '*/*': {}
+    ServeDirNotModifiedResponse:
+      description: Conditional request matched and the file was not modified.
+    ServeDirRedirectResponse:
+      description: Directory path redirected to its trailing-slash form.
+      headers:
+        Location:
+          schema:
+            type: string
+    ServeDirPreconditionFailedResponse:
+      description: A conditional request precondition failed.
+    ServeDirRangeNotSatisfiableResponse:
+      description: Requested range is invalid, unsatisfiable, or contains multiple ranges.
+      headers:
+        Accept-Ranges:
+          schema:
+            type: string
+            const: bytes
+        Last-Modified:
+          schema:
+            type: string
+        Content-Range:
+          schema:
+            type: string
+      content:
+        '*/*': {}
+    ServeDirInternalErrorResponse:
+      description: Static-service redirect construction or file access failed.
   schemas:
     Response:
       type: object
@@ -677,7 +804,7 @@ components:
       enum: [Transmission, AsyncProcess]
     DownloadRequest:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       required: [name, link, engine]
       properties:
         name:
@@ -691,6 +818,47 @@ components:
     TaskState:
       type: object
       additionalProperties: false
+      required:
+        - key
+        - name
+        - displayName
+        - finished
+        - eta
+        - percentDone
+        - sizeDetails
+        - rateDetails
+        - processDetails
+        - errorString
+        - taskType
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        displayName:
+          type: string
+        finished:
+          type: boolean
+        eta:
+          type: integer
+          format: int64
+        percentDone:
+          type: number
+          format: float
+        sizeDetails:
+          type: string
+        rateDetails:
+          type: string
+        processDetails:
+          type: string
+        errorString:
+          type: string
+        taskType:
+          $ref: '#/components/schemas/TaskType'
+    TaskStateRequest:
+      type: object
+      additionalProperties: true
+      description: Inbound task state; all serialized fields are required and unknown fields are ignored by Serde.
       required:
         - key
         - name
@@ -787,7 +955,7 @@ components:
           type: [string, 'null']
     ConversionRequest:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       required: [name]
       properties:
         name:
@@ -1113,6 +1281,15 @@ components:
           description: Raw or semi-structured extractor output.
         extractionError:
           type: string
+    BookMetadataRequest:
+      type: object
+      additionalProperties: true
+      description: Inbound extractor metadata; optional values may be omitted or null and unknown fields are ignored.
+      properties:
+        raw:
+          description: Raw or semi-structured extractor output.
+        extractionError:
+          type: [string, 'null']
     BookCollectionItem:
       type: object
       additionalProperties: false
@@ -1206,9 +1383,56 @@ components:
         url:
           type: string
           description: Webserver-relative URL below /api/books/download/.
+    BookDetailsRequest:
+      type: object
+      additionalProperties: true
+      description: |
+        Inbound BookDetails shape. The runtime uses #[serde(default)], so every
+        field may be omitted and unknown fields are ignored.
+      properties:
+        fileName:
+          type: string
+        collection:
+          type: string
+        title:
+          type: string
+        authors:
+          type: array
+          items:
+            type: string
+        description:
+          type: [string, 'null']
+        publisher:
+          type: [string, 'null']
+        publishedDate:
+          type: [string, 'null']
+        language:
+          type: [string, 'null']
+        isbn:
+          type: [string, 'null']
+        format:
+          $ref: '#/components/schemas/BookFormat'
+        pageCount:
+          type: [integer, 'null']
+          format: int64
+        thumbnail:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/BookMetadataRequest'
+        checksum:
+          type: string
+          pattern: '^-?[0-9]+$'
+        searchPhrase:
+          type: [string, 'null']
+        state:
+          $ref: '#/components/schemas/BookState'
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
     ClientLogMessage:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       required: [level, messages]
       properties:
         level:
@@ -1252,7 +1476,7 @@ components:
           format: int32
     RemotePlayerStateRequest:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       required: [collection, video, videoId, paused]
       properties:
         currentTime:
@@ -1290,6 +1514,20 @@ components:
           $ref: '#/components/schemas/BookDetails'
         checksum:
           type: string
+    BookEventRequest:
+      type: object
+      additionalProperties: true
+      required: [type, checksum]
+      properties:
+        type:
+          type: string
+          enum: [BookEventAdded, BookEventChanged, BookEventDeleted]
+        book:
+          oneOf:
+            - $ref: '#/components/schemas/BookDetailsRequest'
+            - type: 'null'
+        checksum:
+          type: string
     VideoEvent:
       type: object
       additionalProperties: false
@@ -1300,6 +1538,20 @@ components:
           enum: [VideoEventAdded, VideoEventChanged, VideoEventDeleted]
         video:
           $ref: '#/components/schemas/VideoDetails'
+        checksum:
+          type: string
+    VideoEventRequest:
+      type: object
+      additionalProperties: true
+      required: [type, checksum]
+      properties:
+        type:
+          type: string
+          enum: [VideoEventAdded, VideoEventChanged, VideoEventDeleted]
+        video:
+          oneOf:
+            - $ref: '#/components/schemas/VideoDetailsRequest'
+            - type: 'null'
         checksum:
           type: string
     RemoteMessage:
@@ -1430,7 +1682,9 @@ components:
           properties:
             Pong:
               type: string
+              format: socket-address
               description: Socket address such as 192.0.2.1:8080 or [2001:db8::1]:8080.
+              pattern: '^(?:[0-9]{1,3}(?:\.[0-9]{1,3}){3}|\[[0-9A-Fa-f:.%]+\]):[0-9]{1,5}$'
         - type: object
           additionalProperties: false
           required: [Close]
@@ -1475,6 +1729,53 @@ components:
         - $ref: '#/components/schemas/RemoteMessage'
         - type: object
           additionalProperties: false
+          required: [Command]
+          properties:
+            Command:
+              type: object
+              additionalProperties: true
+              required: [command]
+              properties:
+                command:
+                  type: string
+        - type: object
+          additionalProperties: false
+          required: [Seek]
+          properties:
+            Seek:
+              type: object
+              additionalProperties: true
+              required: [interval]
+              properties:
+                interval:
+                  type: integer
+                  format: int32
+        - type: object
+          additionalProperties: false
+          required: [SetAudioTrack]
+          properties:
+            SetAudioTrack:
+              type: object
+              additionalProperties: true
+              required: [trackId]
+              properties:
+                trackId:
+                  type: integer
+                  format: int32
+        - type: object
+          additionalProperties: false
+          required: [SetPlaybackRate]
+          properties:
+            SetPlaybackRate:
+              type: object
+              additionalProperties: true
+              required: [rate]
+              properties:
+                rate:
+                  type: number
+                  format: double
+        - type: object
+          additionalProperties: false
           required: [State]
           properties:
             State:
@@ -1485,7 +1786,7 @@ components:
           properties:
             Play:
               type: object
-              additionalProperties: false
+              additionalProperties: true
               required: [videoId, url, collection, video, width, height, aspectWidth, aspectHeight]
               properties:
                 videoId:
@@ -1518,7 +1819,7 @@ components:
           properties:
             SetSubtitleTrack:
               type: object
-              additionalProperties: false
+              additionalProperties: true
               properties:
                 trackId:
                   type: [integer, 'null']
@@ -1529,6 +1830,30 @@ components:
           properties:
             LastState:
               $ref: '#/components/schemas/VideoDetailsRequest'
+        - type: object
+          additionalProperties: false
+          required: [CurrentTasks]
+          properties:
+            CurrentTasks:
+              type: array
+              items:
+                $ref: '#/components/schemas/TaskStateRequest'
+        - type: object
+          additionalProperties: false
+          required: [Book]
+          properties:
+            Book:
+              type: array
+              items:
+                $ref: '#/components/schemas/BookEventRequest'
+        - type: object
+          additionalProperties: false
+          required: [Video]
+          properties:
+            Video:
+              type: array
+              items:
+                $ref: '#/components/schemas/VideoEventRequest'
     Command:
       type: object
       additionalProperties: true

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,1587 @@
+openapi: 3.1.0
+info:
+  title: TVServer REST API
+  version: 0.8.1
+  description: |
+    Canonical contract for the TVServer webserver API. Book resources are exposed
+    only through the dedicated book routes; the existing media routes remain
+    video-only. Protected routes allow credential-free requests only when the
+    peer address is localhost, IPv6 loopback, or 192.168.* and any X-Real-IP or
+    first X-Forwarded-For value is also in that trusted set. Other callers must
+    use HTTP Basic authentication or the base64 query credential documented below.
+servers:
+  - url: /
+    description: Current TVServer host
+tags:
+  - name: Tasks
+  - name: Media
+  - name: Books
+  - name: Search
+  - name: Remote
+  - name: Diagnostics
+security:
+  - HttpBasicAuth: []
+  - QueryAuth: []
+paths:
+  /api/tasks:
+    get:
+      tags: [Tasks]
+      operationId: listTasks
+      summary: List current download and conversion tasks
+      responses:
+        '200':
+          description: Current task state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskListResults'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+    post:
+      tags: [Tasks]
+      operationId: addTask
+      summary: Queue a download
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DownloadRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+  /api/tasks/{type}/{path}:
+    delete:
+      tags: [Tasks]
+      operationId: deleteTask
+      summary: Remove a task
+      parameters:
+        - name: type
+          in: path
+          required: true
+          description: Serde task type name.
+          schema:
+            $ref: '#/components/schemas/TaskType'
+        - name: path
+          in: path
+          required: true
+          description: Greedy nested path suffix used as the task key; clients send each segment URL-encoded and Axum passes the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+  /api/log:
+    post:
+      tags: [Diagnostics]
+      operationId: logClientMessage
+      summary: Write frontend messages to the server log
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClientLogMessage'
+      responses:
+        '200':
+          description: Messages were logged; the response has no body.
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+  /api/media:
+    get:
+      tags: [Media]
+      operationId: listRootMediaCollection
+      summary: List the root video collection
+      description: Returns only video collections or video records, never books.
+      responses:
+        '200':
+          description: Root video collection
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaItem'
+        '404':
+          description: Video collection error encoded as a MediaItem Error variant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaItem'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+  /api/media/{media}:
+    get:
+      tags: [Media]
+      operationId: listMediaCollection
+      summary: List a nested video collection
+      description: Returns only video collections or video records, never books.
+      parameters:
+        - name: media
+          in: path
+          required: true
+          description: Greedy nested path suffix for the video collection; clients send each segment URL-encoded and Axum passes the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Video collection
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaItem'
+        '404':
+          description: Video collection error encoded as a MediaItem Error variant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaItem'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+    delete:
+      tags: [Media]
+      operationId: deleteVideo
+      summary: Delete a video
+      parameters:
+        - name: media
+          in: path
+          required: true
+          description: Greedy nested path suffix passed to the video store; clients send each segment URL-encoded and Axum passes the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+    post:
+      tags: [Media]
+      operationId: convertVideo
+      summary: Queue a conversion for a video checksum
+      parameters:
+        - name: media
+          in: path
+          required: true
+          description: Decimal video checksum carried in the greedy nested path wildcard; clients send the value URL-encoded and Axum passes the decoded value.
+          schema:
+            type: string
+            pattern: '^-?[0-9]+$'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConversionRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '400':
+          description: The wildcard value is not a valid integer checksum.
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+    patch:
+      tags: [Media]
+      operationId: shareVideo
+      summary: Share a video through the configured media sharer
+      parameters:
+        - name: media
+          in: path
+          required: true
+          description: Greedy nested path suffix passed to the media sharer; clients send each segment URL-encoded and Axum passes the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+  /api/books:
+    get:
+      tags: [Books]
+      operationId: listRootBooks
+      summary: List root book collections and books
+      responses:
+        '200':
+          description: Root book collection
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookCollectionDetails'
+        '500':
+          description: Collection-shaped error response with errors populated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookCollectionDetails'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+  /api/books/{collection}:
+    get:
+      tags: [Books]
+      operationId: listBooks
+      summary: List a nested book collection
+      parameters:
+        - name: collection
+          in: path
+          required: true
+          description: Greedy nested path suffix for the collection; clients send each segment URL-encoded and Axum passes the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Requested book collection
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookCollectionDetails'
+        '500':
+          description: Collection-shaped error response with errors populated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookCollectionDetails'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+  /api/book/{checksum}:
+    get:
+      tags: [Books]
+      operationId: getBook
+      summary: Retrieve one book
+      parameters:
+        - $ref: '#/components/parameters/BookChecksum'
+      responses:
+        '200':
+          description: Book details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookDetails'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+    delete:
+      tags: [Books]
+      operationId: deleteBook
+      summary: Delete one book and its stored files
+      parameters:
+        - $ref: '#/components/parameters/BookChecksum'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+  /api/books/download/{path}:
+    get:
+      tags: [Books]
+      operationId: downloadBook
+      summary: Download a stored PDF or EPUB
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: Greedy nested path suffix relative to BOOK_DIR; clients send each segment URL-encoded and Axum passes the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Book file
+          headers:
+            Content-Length:
+              schema:
+                type: integer
+                minimum: 0
+          content:
+            application/pdf:
+              schema:
+                type: string
+                contentEncoding: binary
+            application/epub+zip:
+              schema:
+                type: string
+                contentEncoding: binary
+        '404':
+          description: Missing, unsupported, or rejected path; the response has no body.
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          description: Static file serving failed; the response has no body.
+  /api/book-thumbnails/{file}:
+    get:
+      tags: [Books]
+      operationId: getBookThumbnail
+      summary: Fetch a generated or default book thumbnail
+      security: []
+      parameters:
+        - name: file
+          in: path
+          required: true
+          description: Single URL-encoded JPEG filename; nested paths are rejected.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: JPEG thumbnail
+          headers:
+            Content-Length:
+              schema:
+                type: integer
+                minimum: 0
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                contentEncoding: binary
+        '404':
+          description: Missing, unsupported, or rejected filename; the response has no body.
+        '500':
+          description: Static file serving failed; the response has no body.
+  /api/remote:
+    get:
+      tags: [Remote]
+      operationId: listRemotePlayers
+      summary: List connected remote players
+      responses:
+        '200':
+          description: Connected player state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlayerList'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+  /api/remote/control:
+    post:
+      tags: [Remote]
+      operationId: sendRemoteCommand
+      summary: Send a serialized remote message to a player
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Command'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+  /api/remote/play:
+    post:
+      tags: [Remote]
+      operationId: playRemoteVideo
+      summary: Ask a remote player to play a video
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlayRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+  /api/remote/ws:
+    get:
+      tags: [Remote]
+      operationId: upgradeRemotePlayerWebSocket
+      summary: Upgrade a remote player connection to WebSocket
+      responses:
+        '101':
+          description: Switching Protocols
+        '400':
+          description: Invalid WebSocket upgrade request
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+  /api/control/ws:
+    get:
+      tags: [Remote]
+      operationId: upgradeRemoteControlWebSocket
+      summary: Upgrade a remote control connection to WebSocket
+      responses:
+        '101':
+          description: Switching Protocols
+        '400':
+          description: Invalid WebSocket upgrade request
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+  /api/search/pirate:
+    get:
+      tags: [Search]
+      operationId: searchPirateBay
+      summary: Search the configured torrent provider
+      parameters:
+        - $ref: '#/components/parameters/SearchQuery'
+      responses:
+        '200':
+          $ref: '#/components/responses/SearchResponse'
+        '400':
+          $ref: '#/components/responses/SearchResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/SearchResponse'
+  /api/search/youtube:
+    get:
+      tags: [Search]
+      operationId: searchYouTube
+      summary: Search YouTube
+      parameters:
+        - $ref: '#/components/parameters/SearchQuery'
+      responses:
+        '200':
+          $ref: '#/components/responses/SearchResponse'
+        '400':
+          $ref: '#/components/responses/SearchResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '500':
+          $ref: '#/components/responses/SearchResponse'
+  /api/conversion:
+    get:
+      tags: [Media]
+      operationId: listConversions
+      summary: List supported video conversions
+      responses:
+        '200':
+          description: Conversion definitions in the standard search-results wrapper
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionResults'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+  /api/stream/{path}:
+    get:
+      tags: [Media]
+      operationId: streamVideo
+      summary: Stream a stored video through the static file service
+      security: []
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: Greedy nested path suffix relative to the movie directory; clients send each segment URL-encoded and the static service receives the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Complete video representation; media type depends on the stored file.
+          content:
+            video/*:
+              schema:
+                type: string
+                contentEncoding: binary
+            application/octet-stream:
+              schema:
+                type: string
+                contentEncoding: binary
+        '206':
+          description: Byte range selected by the static file service.
+          content:
+            video/*:
+              schema:
+                type: string
+                contentEncoding: binary
+            application/octet-stream:
+              schema:
+                type: string
+                contentEncoding: binary
+        '404':
+          description: File not found
+  /api/stream-audio/{audio_index}/{path}:
+    get:
+      tags: [Media]
+      operationId: streamVideoAudioTrack
+      summary: Remux a selected audio track with the first video track
+      security: []
+      parameters:
+        - name: audio_index
+          in: path
+          required: true
+          description: Zero-based audio stream index passed to ffmpeg.
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 4294967295
+        - name: path
+          in: path
+          required: true
+          description: Greedy nested path suffix relative to the movie directory; clients send each segment URL-encoded and Axum passes the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Remuxed Matroska stream
+          content:
+            video/x-matroska:
+              schema:
+                type: string
+                contentEncoding: binary
+        '403':
+          description: Resolved file is outside the movie directory
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: File not found
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Movie directory or ffmpeg failure
+          content:
+            text/plain:
+              schema:
+                type: string
+  /api/thumbnails/{path}:
+    get:
+      tags: [Media]
+      operationId: getVideoThumbnail
+      summary: Fetch a video thumbnail through the static file service
+      security: []
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: Greedy nested path suffix relative to the video thumbnail directory; clients send each segment URL-encoded and the static service receives the decoded value.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Thumbnail bytes; media type depends on the stored image.
+          content:
+            image/*:
+              schema:
+                type: string
+                contentEncoding: binary
+        '404':
+          description: Thumbnail not found
+components:
+  securitySchemes:
+    HttpBasicAuth:
+      type: http
+      scheme: basic
+      description: |
+        For callers outside the trusted local networks, send the exact
+        AUTH_CREDENTIALS value as the HTTP Basic username/password credentials.
+    QueryAuth:
+      type: apiKey
+      in: query
+      name: auth
+      description: |
+        Base64-encoded AUTH_CREDENTIALS value. The middleware accepts this on all
+        protected routes; it exists primarily for browser WebSocket clients that
+        cannot set an Authorization header.
+  parameters:
+    BookChecksum:
+      name: checksum
+      in: path
+      required: true
+      description: Decimal book checksum. It is represented as a string at the HTTP boundary.
+      schema:
+        type: string
+        pattern: '^-?[0-9]+$'
+    SearchQuery:
+      name: q
+      in: query
+      required: true
+      description: Search text.
+      schema:
+        type: string
+  responses:
+    UnauthorizedResponse:
+      description: Caller is outside the trusted local networks and supplied no valid credentials.
+      headers:
+        WWW-Authenticate:
+          description: HTTP Basic authentication challenge emitted by restrict_access.
+          schema:
+            type: string
+          example: 'Basic realm="tvserver"'
+    SuccessResponse:
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Response'
+    ErrorResponse:
+      description: Error response with one or more messages in errors
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    SearchResponse:
+      description: Search results or an error in the same response wrapper
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SearchResults'
+  schemas:
+    Response:
+      type: object
+      additionalProperties: false
+      required: [message, errors]
+      properties:
+        message:
+          type: string
+        errors:
+          type: array
+          items:
+            type: string
+    ErrorResponse:
+      type: object
+      additionalProperties: false
+      required: [message, errors]
+      properties:
+        message:
+          type: string
+        errors:
+          type: array
+          minItems: 1
+          items:
+            type: string
+    SearchEngineType:
+      type: string
+      enum: [YouTube, Torrent, CopyServer]
+    TaskType:
+      type: string
+      enum: [Transmission, AsyncProcess]
+    DownloadRequest:
+      type: object
+      additionalProperties: false
+      required: [name, link, engine]
+      properties:
+        name:
+          type: string
+        link:
+          type: string
+        engine:
+          $ref: '#/components/schemas/SearchEngineType'
+        series:
+          type: [string, 'null']
+    TaskState:
+      type: object
+      additionalProperties: false
+      required:
+        - key
+        - name
+        - displayName
+        - finished
+        - eta
+        - percentDone
+        - sizeDetails
+        - rateDetails
+        - processDetails
+        - errorString
+        - taskType
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        displayName:
+          type: string
+        finished:
+          type: boolean
+        eta:
+          type: integer
+          format: int64
+        percentDone:
+          type: number
+          format: float
+        sizeDetails:
+          type: string
+        rateDetails:
+          type: string
+        processDetails:
+          type: string
+        errorString:
+          type: string
+        taskType:
+          $ref: '#/components/schemas/TaskType'
+    TaskListResults:
+      type: object
+      additionalProperties: false
+      required: [results, error]
+      properties:
+        results:
+          type: [array, 'null']
+          items:
+            $ref: '#/components/schemas/TaskState'
+        error:
+          type: [string, 'null']
+    SearchResults:
+      type: object
+      additionalProperties: false
+      required: [results, error]
+      properties:
+        results:
+          type: [array, 'null']
+          items:
+            type: object
+            additionalProperties: false
+            required: [title, description, link, engine]
+            properties:
+              title:
+                type: string
+              description:
+                type: string
+              link:
+                type: string
+              engine:
+                $ref: '#/components/schemas/SearchEngineType'
+        error:
+          type: [string, 'null']
+    ConversionResults:
+      type: object
+      additionalProperties: false
+      required: [results, error]
+      properties:
+        results:
+          type: [array, 'null']
+          items:
+            type: object
+            additionalProperties: false
+            required: [name, description, exec, args, extension]
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+              exec:
+                type: string
+              args:
+                type: string
+              extension:
+                type: [string, 'null']
+        error:
+          type: [string, 'null']
+    ConversionRequest:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+    CollectionItem:
+      type: object
+      additionalProperties: false
+      required: [collection, thumbnail]
+      properties:
+        collection:
+          type: string
+        thumbnail:
+          type: array
+          items:
+            type: string
+    CollectionDetails:
+      type: object
+      additionalProperties: false
+      required: [collection, parent_collection, child_collections, series, videos, errors]
+      properties:
+        collection:
+          type: string
+        parent_collection:
+          type: string
+        child_collections:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectionItem'
+        series:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/VideoDetails'
+        videos:
+          type: array
+          items:
+            $ref: '#/components/schemas/MediaItem'
+        errors:
+          type: array
+          items:
+            type: string
+    MediaItem:
+      description: Externally tagged Serde enum containing only existing video-media variants.
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required: [Collection]
+          properties:
+            Collection:
+              $ref: '#/components/schemas/CollectionDetails'
+        - type: object
+          additionalProperties: false
+          required: [Video]
+          properties:
+            Video:
+              $ref: '#/components/schemas/VideoDetails'
+        - type: object
+          additionalProperties: false
+          required: [Error]
+          properties:
+            Error:
+              type: string
+    AudioTrack:
+      type: object
+      additionalProperties: false
+      required: [id, language, title, codec]
+      properties:
+        id:
+          type: integer
+          format: int64
+        language:
+          type: string
+        title:
+          type: [string, 'null']
+        codec:
+          type: [string, 'null']
+    SubtitleTrack:
+      type: object
+      additionalProperties: false
+      required: [id, language, title, codec]
+      properties:
+        id:
+          type: integer
+          format: int64
+        language:
+          type: string
+        title:
+          type: [string, 'null']
+        codec:
+          type: [string, 'null']
+    VideoMetadata:
+      type: object
+      additionalProperties: false
+      required: [duration, width, height, aspectWidth, aspectHeight, audioTracks]
+      properties:
+        duration:
+          type: number
+          format: double
+        width:
+          type: integer
+          minimum: 0
+        height:
+          type: integer
+          minimum: 0
+        aspectWidth:
+          type: integer
+          minimum: 0
+        aspectHeight:
+          type: integer
+          minimum: 0
+        audioTracks:
+          type: integer
+          minimum: 0
+        audioTrackList:
+          type: array
+          items:
+            $ref: '#/components/schemas/AudioTrack'
+        subtitleTracks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubtitleTrack'
+    SeriesDetails:
+      type: object
+      additionalProperties: false
+      required: [seriesTitle, season, episode, episodeTitle]
+      properties:
+        seriesTitle:
+          type: string
+        season:
+          type: string
+        episode:
+          type: string
+        episodeTitle:
+          type: string
+    VideoMetadataRequest:
+      type: object
+      additionalProperties: true
+      required: [duration, width, height, aspectWidth, aspectHeight, audioTracks]
+      description: Inbound video metadata shape; optional track lists may be omitted or null and unknown fields are ignored by Serde.
+      properties:
+        duration:
+          type: number
+          format: double
+        width:
+          type: integer
+          minimum: 0
+          maximum: 4294967295
+        height:
+          type: integer
+          minimum: 0
+          maximum: 4294967295
+        aspectWidth:
+          type: integer
+          minimum: 0
+          maximum: 4294967295
+        aspectHeight:
+          type: integer
+          minimum: 0
+          maximum: 4294967295
+        audioTracks:
+          type: integer
+          minimum: 0
+          maximum: 4294967295
+        audioTrackList:
+          type: [array, 'null']
+          items:
+            type: object
+            additionalProperties: true
+            required: [id, language]
+            properties:
+              id:
+                type: integer
+                format: int64
+              language:
+                type: string
+              title:
+                type: [string, 'null']
+              codec:
+                type: [string, 'null']
+        subtitleTracks:
+          type: [array, 'null']
+          items:
+            type: object
+            additionalProperties: true
+            required: [id, language]
+            properties:
+              id:
+                type: integer
+                format: int64
+              language:
+                type: string
+              title:
+                type: [string, 'null']
+              codec:
+                type: [string, 'null']
+    SeriesDetailsRequest:
+      type: object
+      additionalProperties: true
+      required: [seriesTitle, season, episode, episodeTitle]
+      description: Inbound series shape; all fields are required when present and unknown fields are ignored by Serde.
+      properties:
+        seriesTitle:
+          type: string
+        season:
+          type: string
+        episode:
+          type: string
+        episodeTitle:
+          type: string
+    VideoState:
+      type: string
+      enum:
+        - Ready
+        - NewFile
+        - ZeroFileSize
+        - NoVideoSize
+        - NeedThumbnail
+        - NeedVideoMetaData
+        - NeedDescription
+        - Exception
+    VideoDetails:
+      type: object
+      additionalProperties: false
+      required:
+        - video
+        - collection
+        - description
+        - series
+        - thumbnail
+        - metadata
+        - checksum
+        - state
+        - createdOn
+        - updatedOn
+        - url
+      properties:
+        video:
+          type: string
+        collection:
+          type: string
+        description:
+          type: string
+        series:
+          $ref: '#/components/schemas/SeriesDetails'
+        thumbnail:
+          type: array
+          items:
+            type: string
+        metadata:
+          $ref: '#/components/schemas/VideoMetadata'
+        checksum:
+          type: string
+          pattern: '^-?[0-9]+$'
+        searchPhrase:
+          type: string
+        state:
+          $ref: '#/components/schemas/VideoState'
+        createdOn:
+          type: string
+          description: Naive local date-time serialized by chrono without a UTC offset.
+        updatedOn:
+          type: string
+          description: Naive local date-time serialized by chrono without a UTC offset.
+        playFrom:
+          type: number
+          format: float
+        lastViewed:
+          type: string
+          description: Naive local date-time serialized by chrono without a UTC offset.
+        url:
+          type: string
+          description: Webserver-relative URL below /api/stream/.
+    VideoDetailsRequest:
+      type: object
+      additionalProperties: true
+      description: |
+        Inbound VideoDetails shape. The runtime uses #[serde(default)], so every
+        field may be omitted and unknown fields are ignored.
+      properties:
+        video:
+          type: string
+        collection:
+          type: string
+        description:
+          type: string
+        series:
+          $ref: '#/components/schemas/SeriesDetailsRequest'
+        thumbnail:
+          type: array
+          items:
+            type: string
+        metadata:
+          $ref: '#/components/schemas/VideoMetadataRequest'
+        checksum:
+          type: string
+          pattern: '^-?[0-9]+$'
+        searchPhrase:
+          type: [string, 'null']
+        state:
+          $ref: '#/components/schemas/VideoState'
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+        playFrom:
+          type: [number, 'null']
+          format: float
+        lastViewed:
+          type: [string, 'null']
+    BookFormat:
+      type: string
+      enum: [pdf, epub]
+    BookState:
+      type: string
+      enum: [Ready, NewFile, NeedMetadata, NeedThumbnail, MetadataError, ZeroFileSize, Exception]
+    BookMetadata:
+      type: object
+      additionalProperties: false
+      description: Optional extractor output. Both fields are omitted when absent.
+      properties:
+        raw:
+          description: Raw or semi-structured extractor output.
+        extractionError:
+          type: string
+    BookCollectionItem:
+      type: object
+      additionalProperties: false
+      required: [collection, thumbnail]
+      properties:
+        collection:
+          type: string
+        thumbnail:
+          type: string
+          description: Webserver-relative URL below /api/book-thumbnails/.
+    BookCollectionDetails:
+      type: object
+      additionalProperties: false
+      required: [collection, parentCollection, childCollections, books, errors]
+      properties:
+        collection:
+          type: string
+        parentCollection:
+          type: string
+        childCollections:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookCollectionItem'
+        books:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookDetails'
+        errors:
+          type: array
+          items:
+            type: string
+    BookDetails:
+      type: object
+      additionalProperties: false
+      required:
+        - fileName
+        - collection
+        - title
+        - authors
+        - format
+        - thumbnail
+        - checksum
+        - state
+        - createdOn
+        - updatedOn
+        - url
+      properties:
+        fileName:
+          type: string
+        collection:
+          type: string
+        title:
+          type: string
+        authors:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+        publisher:
+          type: string
+        publishedDate:
+          type: string
+        language:
+          type: string
+        isbn:
+          type: string
+        format:
+          $ref: '#/components/schemas/BookFormat'
+        pageCount:
+          type: integer
+          format: int64
+        thumbnail:
+          type: string
+          description: Webserver-relative URL below /api/book-thumbnails/.
+        metadata:
+          $ref: '#/components/schemas/BookMetadata'
+        checksum:
+          type: string
+          pattern: '^-?[0-9]+$'
+        searchPhrase:
+          type: string
+        state:
+          $ref: '#/components/schemas/BookState'
+        createdOn:
+          type: string
+          description: Naive local date-time serialized by chrono without a UTC offset.
+        updatedOn:
+          type: string
+          description: Naive local date-time serialized by chrono without a UTC offset.
+        url:
+          type: string
+          description: Webserver-relative URL below /api/books/download/.
+    ClientLogMessage:
+      type: object
+      additionalProperties: false
+      required: [level, messages]
+      properties:
+        level:
+          type: string
+        messages:
+          type: array
+          items:
+            type: string
+    RemotePlayerState:
+      type: object
+      additionalProperties: false
+      required:
+        - currentTime
+        - duration
+        - collection
+        - video
+        - videoId
+        - paused
+        - playbackRate
+        - currentSubtitleTrack
+      properties:
+        currentTime:
+          type: number
+          format: double
+        duration:
+          type: number
+          format: double
+        collection:
+          type: string
+        video:
+          type: string
+        videoId:
+          type: string
+        paused:
+          type: boolean
+        playbackRate:
+          type: number
+          format: double
+        currentSubtitleTrack:
+          type: [integer, 'null']
+          format: int32
+    RemotePlayerStateRequest:
+      type: object
+      additionalProperties: false
+      required: [collection, video, videoId, paused]
+      properties:
+        currentTime:
+          type: [number, 'null']
+          format: double
+          description: Missing or null values deserialize to 0.
+        duration:
+          type: [number, 'null']
+          format: double
+          description: Missing or null values deserialize to 0.
+        collection:
+          type: string
+        video:
+          type: string
+        videoId:
+          type: string
+        paused:
+          type: boolean
+        playbackRate:
+          type: [number, 'null']
+          format: double
+          description: Missing or null values deserialize to 1.0.
+        currentSubtitleTrack:
+          type: [integer, 'null']
+          format: int32
+    BookEvent:
+      type: object
+      additionalProperties: false
+      required: [type, checksum]
+      properties:
+        type:
+          type: string
+          enum: [BookEventAdded, BookEventChanged, BookEventDeleted]
+        book:
+          $ref: '#/components/schemas/BookDetails'
+        checksum:
+          type: string
+    VideoEvent:
+      type: object
+      additionalProperties: false
+      required: [type, checksum]
+      properties:
+        type:
+          type: string
+          enum: [VideoEventAdded, VideoEventChanged, VideoEventDeleted]
+        video:
+          $ref: '#/components/schemas/VideoDetails'
+        checksum:
+          type: string
+    RemoteMessage:
+      description: Externally tagged Serde enum as serialized in player state responses.
+      oneOf:
+        - type: string
+          enum: [Stop, SendLastState]
+        - type: object
+          additionalProperties: false
+          required: [Command]
+          properties:
+            Command:
+              type: object
+              additionalProperties: false
+              required: [command]
+              properties:
+                command:
+                  type: string
+        - type: object
+          additionalProperties: false
+          required: [Play]
+          properties:
+            Play:
+              type: object
+              additionalProperties: false
+              required: [videoId, url, collection, video, width, height, aspectWidth, aspectHeight, metadata]
+              properties:
+                videoId:
+                  type: string
+                url:
+                  type: string
+                collection:
+                  type: string
+                video:
+                  type: string
+                width:
+                  type: integer
+                  format: int32
+                height:
+                  type: integer
+                  format: int32
+                aspectWidth:
+                  type: integer
+                  format: int32
+                aspectHeight:
+                  type: integer
+                  format: int32
+                metadata:
+                  oneOf:
+                    - $ref: '#/components/schemas/VideoMetadata'
+                    - type: 'null'
+        - type: object
+          additionalProperties: false
+          required: [Seek]
+          properties:
+            Seek:
+              type: object
+              additionalProperties: false
+              required: [interval]
+              properties:
+                interval:
+                  type: integer
+                  format: int32
+        - type: object
+          additionalProperties: false
+          required: [SetAudioTrack]
+          properties:
+            SetAudioTrack:
+              type: object
+              additionalProperties: false
+              required: [trackId]
+              properties:
+                trackId:
+                  type: integer
+                  format: int32
+        - type: object
+          additionalProperties: false
+          required: [SetPlaybackRate]
+          properties:
+            SetPlaybackRate:
+              type: object
+              additionalProperties: false
+              required: [rate]
+              properties:
+                rate:
+                  type: number
+                  format: double
+        - type: object
+          additionalProperties: false
+          required: [SetSubtitleTrack]
+          properties:
+            SetSubtitleTrack:
+              type: object
+              additionalProperties: false
+              required: [trackId]
+              properties:
+                trackId:
+                  type: [integer, 'null']
+                  format: int32
+        - type: object
+          additionalProperties: false
+          required: [TogglePause]
+          properties:
+            TogglePause:
+              type: string
+        - type: object
+          additionalProperties: false
+          required: [State]
+          properties:
+            State:
+              $ref: '#/components/schemas/RemotePlayerState'
+        - type: object
+          additionalProperties: false
+          required: [Error]
+          properties:
+            Error:
+              type: string
+        - type: object
+          additionalProperties: false
+          required: [Ping]
+          properties:
+            Ping:
+              type: integer
+              minimum: 0
+        - type: object
+          additionalProperties: false
+          required: [Pong]
+          properties:
+            Pong:
+              type: string
+              description: Socket address such as 192.0.2.1:8080 or [2001:db8::1]:8080.
+        - type: object
+          additionalProperties: false
+          required: [Close]
+          properties:
+            Close:
+              type: string
+        - type: object
+          additionalProperties: false
+          required: [LastState]
+          properties:
+            LastState:
+              $ref: '#/components/schemas/VideoDetails'
+        - type: object
+          additionalProperties: false
+          required: [CurrentTasks]
+          properties:
+            CurrentTasks:
+              type: array
+              items:
+                $ref: '#/components/schemas/TaskState'
+        - type: object
+          additionalProperties: false
+          required: [Book]
+          properties:
+            Book:
+              type: array
+              items:
+                $ref: '#/components/schemas/BookEvent'
+        - type: object
+          additionalProperties: false
+          required: [Video]
+          properties:
+            Video:
+              type: array
+              items:
+                $ref: '#/components/schemas/VideoEvent'
+    RemoteMessageRequest:
+      description: |
+        RemoteMessage input shape. It includes the serialized response shape plus
+        the looser forms accepted by custom/default Serde deserialization.
+      anyOf:
+        - $ref: '#/components/schemas/RemoteMessage'
+        - type: object
+          additionalProperties: false
+          required: [State]
+          properties:
+            State:
+              $ref: '#/components/schemas/RemotePlayerStateRequest'
+        - type: object
+          additionalProperties: false
+          required: [Play]
+          properties:
+            Play:
+              type: object
+              additionalProperties: false
+              required: [videoId, url, collection, video, width, height, aspectWidth, aspectHeight]
+              properties:
+                videoId:
+                  type: string
+                url:
+                  type: string
+                collection:
+                  type: string
+                video:
+                  type: string
+                width:
+                  type: integer
+                  format: int32
+                height:
+                  type: integer
+                  format: int32
+                aspectWidth:
+                  type: integer
+                  format: int32
+                aspectHeight:
+                  type: integer
+                  format: int32
+                metadata:
+                  oneOf:
+                    - $ref: '#/components/schemas/VideoMetadataRequest'
+                    - type: 'null'
+        - type: object
+          additionalProperties: false
+          required: [SetSubtitleTrack]
+          properties:
+            SetSubtitleTrack:
+              type: object
+              additionalProperties: false
+              properties:
+                trackId:
+                  type: [integer, 'null']
+                  format: int32
+        - type: object
+          additionalProperties: false
+          required: [LastState]
+          properties:
+            LastState:
+              $ref: '#/components/schemas/VideoDetailsRequest'
+    Command:
+      type: object
+      additionalProperties: true
+      required: [message]
+      properties:
+        remoteAddress:
+          type: [string, 'null']
+        message:
+          $ref: '#/components/schemas/RemoteMessageRequest'
+    PlayRequest:
+      type: object
+      additionalProperties: true
+      required: [collection, video, width, height, aspectWidth, aspectHeight, videoId]
+      properties:
+        collection:
+          type: string
+        video:
+          type: string
+        remoteAddress:
+          type: [string, 'null']
+        width:
+          type: integer
+          format: int32
+        height:
+          type: integer
+          format: int32
+        aspectWidth:
+          type: integer
+          format: int32
+        aspectHeight:
+          type: integer
+          format: int32
+        videoId:
+          type: string
+        metadata:
+          oneOf:
+            - $ref: '#/components/schemas/VideoMetadataRequest'
+            - type: 'null'
+    PlayerListItem:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+        last_message:
+          $ref: '#/components/schemas/RemoteMessage'
+    PlayerList:
+      type: object
+      additionalProperties: false
+      required: [players]
+      properties:
+        players:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlayerListItem'

--- a/tests/openapi_contract_test.rs
+++ b/tests/openapi_contract_test.rs
@@ -1,10 +1,13 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
+    net::SocketAddr,
     path::Path,
 };
 
-use app_lib::domain::messages::{Command, PlayRequest};
+use app_lib::domain::messages::{
+    ClientLogMessage, Command, ConversionRequest, DownloadRequest, PlayRequest, RemoteMessage,
+};
 use roas::validation::{Options as RoasOptions, Validate as RoasValidate};
 use serde_json::Value;
 
@@ -95,6 +98,26 @@ fn schema_accepts(document: &Value, schema: &Value, instance: &Value) -> bool {
         }
     }
 
+    if let (Some(pattern), Some(string)) =
+        (schema.get("pattern").and_then(Value::as_str), instance.as_str())
+    {
+        if !regex::Regex::new(pattern)
+            .expect("OpenAPI patterns must be valid regular expressions")
+            .is_match(string)
+        {
+            return false;
+        }
+    }
+
+    if schema.get("format").and_then(Value::as_str) == Some("socket-address") {
+        let Some(string) = instance.as_str() else {
+            return false;
+        };
+        if string.parse::<SocketAddr>().is_err() {
+            return false;
+        }
+    }
+
     let matches_type = |schema_type: &str| match schema_type {
         "array" => instance.is_array(),
         "boolean" => instance.is_boolean(),
@@ -179,7 +202,12 @@ fn valid_response_code(code: &str) -> bool {
             || (bytes[1] == b'X' && bytes[2] == b'X'))
 }
 
-fn validate_content_schemas(errors: &mut Vec<String>, context: &str, content: &Value) {
+fn validate_content_schemas(
+    errors: &mut Vec<String>,
+    context: &str,
+    content: &Value,
+    allow_empty_media_type_object: bool,
+) {
     let Some(content) = content.as_object() else {
         errors.push(format!("{context} content must be an object"));
         return;
@@ -188,10 +216,28 @@ fn validate_content_schemas(errors: &mut Vec<String>, context: &str, content: &V
         errors.push(format!("{context} content must not be empty"));
     }
     for (media_type, media) in content {
-        if media.get("schema").and_then(Value::as_object).is_none() {
+        if !media.is_object() {
+            errors.push(format!(
+                "{context} media type {media_type} must be a Media Type Object"
+            ));
+        } else if media.get("schema").and_then(Value::as_object).is_none()
+            && !(allow_empty_media_type_object
+                && media.as_object().is_some_and(serde_json::Map::is_empty))
+        {
             errors.push(format!("{context} media type {media_type} must define a schema"));
         }
     }
+}
+
+fn allows_empty_response_media_type(path: &str, method: &str, status: &str) -> bool {
+    matches!(
+        (path, method, status),
+        ("/api/books/download/{path}", "get", "200")
+            | ("/api/book-thumbnails/{file}", "get", "200")
+            | ("/api/stream/{path}", "get", "200" | "206" | "416")
+            | ("/api/stream-audio/{audio_index}/{path}", "get", "200")
+            | ("/api/thumbnails/{path}", "get", "200" | "206" | "416")
+    )
 }
 
 fn semantic_contract_errors(document: &Value) -> Vec<String> {
@@ -294,6 +340,7 @@ fn semantic_contract_errors(document: &Value) -> Vec<String> {
                         &mut errors,
                         &format!("{context} request body"),
                         content,
+                        false,
                     ),
                     None => errors.push(format!("{context} request body must define content")),
                 }
@@ -323,6 +370,7 @@ fn semantic_contract_errors(document: &Value) -> Vec<String> {
                         &mut errors,
                         &format!("{context} response {code}"),
                         content,
+                        allows_empty_response_media_type(path, method, code),
                     );
                 }
             }
@@ -623,6 +671,75 @@ fn remote_request_schemas_accept_runtime_valid_serde_payloads() {
             }
         }),
         serde_json::json!({"message": {"SetSubtitleTrack": {"trackId": null}}}),
+        serde_json::json!({"message": {"Command": {"command": "stop", "ignored": true}}}),
+        serde_json::json!({"message": {"Seek": {"interval": 30, "ignored": true}}}),
+        serde_json::json!({"message": {"SetAudioTrack": {"trackId": 1, "ignored": true}}}),
+        serde_json::json!({"message": {"SetPlaybackRate": {"rate": 1.25, "ignored": true}}}),
+        serde_json::json!({
+            "message": {
+                "State": {
+                    "collection": "Series",
+                    "video": "episode.webm",
+                    "videoId": "42",
+                    "paused": false,
+                    "ignored": true
+                }
+            }
+        }),
+        serde_json::json!({
+            "message": {
+                "Play": {
+                    "videoId": "42",
+                    "url": "/api/stream/episode.webm",
+                    "collection": "",
+                    "video": "episode.webm",
+                    "width": 1920,
+                    "height": 1080,
+                    "aspectWidth": 16,
+                    "aspectHeight": 9,
+                    "ignored": true
+                }
+            }
+        }),
+        serde_json::json!({"message": {"SetSubtitleTrack": {"ignored": true}}}),
+        serde_json::json!({
+            "message": {
+                "CurrentTasks": [{
+                    "key": "task-1",
+                    "name": "download",
+                    "displayName": "Download",
+                    "finished": false,
+                    "eta": 10,
+                    "percentDone": 50.0,
+                    "sizeDetails": "1 MB",
+                    "rateDetails": "1 MB/s",
+                    "processDetails": "running",
+                    "errorString": "",
+                    "taskType": "Transmission",
+                    "ignored": true
+                }]
+            }
+        }),
+        serde_json::json!({
+            "message": {
+                "Book": [{
+                    "type": "BookEventAdded",
+                    "book": {"ignoredBookField": true},
+                    "checksum": "42",
+                    "ignoredEventField": true
+                }]
+            }
+        }),
+        serde_json::json!({
+            "message": {
+                "Video": [{
+                    "type": "VideoEventAdded",
+                    "video": {"ignoredVideoField": true},
+                    "checksum": "42",
+                    "ignoredEventField": true
+                }]
+            }
+        }),
     ];
     for fixture in command_fixtures {
         serde_json::from_value::<Command>(fixture.clone())
@@ -666,6 +783,74 @@ fn remote_request_schemas_accept_runtime_valid_serde_payloads() {
         &schemas["PlayRequest"],
         &play_request_with_null_metadata
     ));
+
+    for (schema_name, fixture) in [
+        (
+            "DownloadRequest",
+            serde_json::json!({
+                "name": "Example",
+                "link": "magnet:?xt=urn:example",
+                "engine": "Torrent",
+                "series": null,
+                "ignored": true
+            }),
+        ),
+        (
+            "ClientLogMessage",
+            serde_json::json!({"level": "info", "messages": ["hello"], "ignored": true}),
+        ),
+        (
+            "ConversionRequest",
+            serde_json::json!({"name": "mobile", "ignored": true}),
+        ),
+    ] {
+        match schema_name {
+            "DownloadRequest" => {
+                serde_json::from_value::<DownloadRequest>(fixture.clone()).unwrap();
+            }
+            "ClientLogMessage" => {
+                serde_json::from_value::<ClientLogMessage>(fixture.clone()).unwrap();
+            }
+            "ConversionRequest" => {
+                serde_json::from_value::<ConversionRequest>(fixture.clone()).unwrap();
+            }
+            _ => unreachable!(),
+        }
+        assert!(
+            schema_accepts(&document, &schemas[schema_name], &fixture),
+            "{schema_name} schema rejected a runtime-valid unknown property"
+        );
+    }
+
+    let pong_schema = schemas["RemoteMessage"]["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find_map(|variant| variant.pointer("/properties/Pong"))
+        .expect("RemoteMessage must define its Pong payload");
+    assert_eq!(pong_schema["format"], "socket-address");
+    for valid_address in
+        ["127.0.0.1:0", "255.255.255.255:65535", "[::1]:8080", "[2001:db8::1]:65535"]
+    {
+        let valid_pong = serde_json::json!({"Pong": valid_address});
+        serde_json::from_value::<RemoteMessage>(valid_pong.clone())
+            .expect("runtime accepts a valid socket address");
+        assert!(
+            schema_accepts(&document, &schemas["RemoteMessageRequest"], &valid_pong),
+            "Pong input schema must accept valid SocketAddr {valid_address}"
+        );
+    }
+
+    for invalid_address in
+        ["not-an-address", "999.999.999.999:8080", "127.0.0.1:99999", "[::::]:8080"]
+    {
+        let invalid_pong = serde_json::json!({"Pong": invalid_address});
+        assert!(serde_json::from_value::<RemoteMessage>(invalid_pong.clone()).is_err());
+        assert!(
+            !schema_accepts(&document, &schemas["RemoteMessageRequest"], &invalid_pong),
+            "Pong input schema must reject invalid SocketAddr {invalid_address}"
+        );
+    }
 }
 
 #[test]
@@ -822,19 +1007,114 @@ fn security_contract_matches_restrict_access_router_layering() {
 }
 
 #[test]
-fn stream_responses_cover_all_video_content_types() {
+fn raw_file_responses_use_openapi_31_binary_media_types() {
     let document = contract();
-    for status in ["200", "206"] {
-        let content = document["paths"]["/api/stream/{path}"]["get"]["responses"][status]
-            ["content"]
+    for (path, status) in [
+        ("/api/books/download/{path}", "200"),
+        ("/api/book-thumbnails/{file}", "200"),
+        ("/api/stream/{path}", "200"),
+        ("/api/stream/{path}", "206"),
+        ("/api/stream-audio/{audio_index}/{path}", "200"),
+        ("/api/thumbnails/{path}", "200"),
+        ("/api/thumbnails/{path}", "206"),
+        ("/api/stream/{path}", "416"),
+        ("/api/thumbnails/{path}", "416"),
+    ] {
+        let response = resolved(&document, &document["paths"][path]["get"]["responses"][status]);
+        let content = response["content"]
             .as_object()
-            .unwrap();
-        let content_types: BTreeSet<_> = content.keys().map(String::as_str).collect();
+            .unwrap_or_else(|| panic!("{path} response {status} must define content"));
+        for (media_type, media) in content {
+            assert_eq!(
+                media,
+                &serde_json::json!({}),
+                "raw {media_type} response {status} for {path} must use an empty Media Type Object"
+            );
+        }
+    }
+}
+
+#[test]
+fn serve_dir_contract_documents_runtime_responses_and_headers() {
+    let document = contract();
+    for path in ["/api/stream/{path}", "/api/thumbnails/{path}"] {
+        let responses = &document["paths"][path]["get"]["responses"];
+        for status in ["200", "206", "304", "307", "404", "412", "416", "500"] {
+            assert!(
+                responses.get(status).is_some(),
+                "ServeDir route {path} must document status {status}"
+            );
+        }
+
+        for status in ["200", "206"] {
+            let response = resolved(&document, &responses[status]);
+            let content = response["content"].as_object().unwrap();
+            assert_eq!(
+                content,
+                &serde_json::Map::from_iter([("*/*".to_string(), serde_json::json!({}))]),
+                "ServeDir guesses MIME from any served file extension"
+            );
+            for header in ["Accept-Ranges", "Content-Length", "Last-Modified"] {
+                assert!(response["headers"].get(header).is_some());
+            }
+        }
+        assert!(resolved(&document, &responses["206"])["headers"]
+            .get("Content-Range")
+            .is_some());
+        assert!(resolved(&document, &responses["307"])["headers"]
+            .get("Location")
+            .is_some());
+        assert!(resolved(&document, &responses["416"])["headers"]
+            .get("Content-Range")
+            .is_some());
+    }
+}
+
+#[test]
+fn axum_extractor_rejections_are_documented_as_plain_text() {
+    let document = contract();
+    let expected_components = [
+        ("400", "#/components/responses/BadRequestTextResponse"),
+        ("413", "#/components/responses/PayloadTooLargeTextResponse"),
+        ("415", "#/components/responses/UnsupportedMediaTypeTextResponse"),
+        ("422", "#/components/responses/UnprocessableEntityTextResponse"),
+    ];
+
+    for (path, method) in [
+        ("/api/tasks", "post"),
+        ("/api/log", "post"),
+        ("/api/media/{media}", "post"),
+        ("/api/remote/control", "post"),
+        ("/api/remote/play", "post"),
+    ] {
+        for (status, reference) in expected_components {
+            assert_eq!(
+                document["paths"][path][method]["responses"][status]["$ref"], reference,
+                "{method} {path} must document Axum JSON rejection {status}"
+            );
+        }
+    }
+
+    for (path, method) in [
+        ("/api/tasks/{type}/{path}", "delete"),
+        ("/api/media/{media}", "get"),
+        ("/api/media/{media}", "delete"),
+        ("/api/media/{media}", "patch"),
+        ("/api/books/{collection}", "get"),
+        ("/api/books/download/{path}", "get"),
+        ("/api/book-thumbnails/{file}", "get"),
+        ("/api/stream-audio/{audio_index}/{path}", "get"),
+    ] {
         assert_eq!(
-            content_types,
-            BTreeSet::from(["video/*", "application/octet-stream"]),
-            "stream response {status} must cover every ServeDir video MIME plus its fallback"
+            document["paths"][path][method]["responses"]["400"]["$ref"],
+            "#/components/responses/BadRequestTextResponse",
+            "{method} {path} must document Axum path rejection"
         );
+    }
+
+    for (_, reference) in expected_components {
+        let response = resolve_local_reference(&document, reference).unwrap();
+        assert_eq!(response["content"]["text/plain"]["schema"]["type"], "string");
     }
 }
 
@@ -878,6 +1158,10 @@ fn project_semantic_checks_reject_representative_contract_defects() {
         .as_object_mut()
         .unwrap()
         .remove("schema");
+    document["paths"]["/api/media"]["get"]["responses"]["200"]["content"]["application/json"]
+        .as_object_mut()
+        .unwrap()
+        .remove("schema");
     let response_schema = document["components"]["schemas"]["Response"].clone();
     document["components"]["schemas"]
         .as_object_mut()
@@ -891,6 +1175,7 @@ fn project_semantic_checks_reject_representative_contract_defects() {
         "response 200 must have a description",
         "invalid response code 099",
         "media type application/json must define a schema",
+        "GET /api/media response 200 media type application/json must define a schema",
         "invalid component key schemas.invalid component key",
     ] {
         assert!(

--- a/tests/openapi_contract_test.rs
+++ b/tests/openapi_contract_test.rs
@@ -1,0 +1,901 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+};
+
+use app_lib::domain::messages::{Command, PlayRequest};
+use roas::validation::{Options as RoasOptions, Validate as RoasValidate};
+use serde_json::Value;
+
+const CONTRACT_PATH: &str = "docs/api/openapi.yaml";
+
+fn contract() -> Value {
+    let source = fs::read_to_string(CONTRACT_PATH)
+        .unwrap_or_else(|error| panic!("failed to read {CONTRACT_PATH}: {error}"));
+    let specification = oas3::from_yaml(source.as_str())
+        .unwrap_or_else(|error| panic!("{CONTRACT_PATH} failed typed OpenAPI parsing: {error}"));
+    specification
+        .validate_version()
+        .unwrap_or_else(|error| panic!("{CONTRACT_PATH} has an unsupported version: {error}"));
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&source)
+        .unwrap_or_else(|error| panic!("failed to parse {CONTRACT_PATH} as YAML: {error}"));
+    serde_json::to_value(yaml).expect("OpenAPI YAML should convert to a JSON value")
+}
+
+#[test]
+fn roas_semantically_validates_the_openapi_31_document() {
+    let document = contract();
+    let specification: roas::v3_1::spec::Spec =
+        serde_json::from_value(document).expect("roas must deserialize the OpenAPI 3.1 document");
+    specification
+        .validate(RoasOptions::empty(), None)
+        .unwrap_or_else(|error| panic!("roas semantic validation failed:\n{error}"));
+}
+
+fn resolve_local_reference<'a>(document: &'a Value, reference: &str) -> Option<&'a Value> {
+    let pointer = reference.strip_prefix('#')?;
+    document.pointer(pointer)
+}
+
+fn visit_references(value: &Value, visit: &mut impl FnMut(&str)) {
+    match value {
+        Value::Object(object) => {
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                visit(reference);
+            }
+            for child in object.values() {
+                visit_references(child, visit);
+            }
+        }
+        Value::Array(array) => {
+            for child in array {
+                visit_references(child, visit);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn template_parameters(path: &str) -> Vec<&str> {
+    path.split('{')
+        .skip(1)
+        .filter_map(|part| part.split_once('}').map(|(parameter, _)| parameter))
+        .collect()
+}
+
+fn resolved<'a>(document: &'a Value, value: &'a Value) -> &'a Value {
+    value
+        .get("$ref")
+        .and_then(Value::as_str)
+        .and_then(|reference| resolve_local_reference(document, reference))
+        .unwrap_or(value)
+}
+
+fn schema_accepts(document: &Value, schema: &Value, instance: &Value) -> bool {
+    let schema = resolved(document, schema);
+
+    if let Some(variants) = schema.get("anyOf").and_then(Value::as_array) {
+        return variants
+            .iter()
+            .any(|variant| schema_accepts(document, variant, instance));
+    }
+
+    if let Some(variants) = schema.get("oneOf").and_then(Value::as_array) {
+        return variants
+            .iter()
+            .filter(|variant| schema_accepts(document, variant, instance))
+            .count()
+            == 1;
+    }
+
+    if let Some(values) = schema.get("enum").and_then(Value::as_array) {
+        if !values.contains(instance) {
+            return false;
+        }
+    }
+
+    let matches_type = |schema_type: &str| match schema_type {
+        "array" => instance.is_array(),
+        "boolean" => instance.is_boolean(),
+        "integer" => instance.as_i64().is_some() || instance.as_u64().is_some(),
+        "null" => instance.is_null(),
+        "number" => instance.is_number(),
+        "object" => instance.is_object(),
+        "string" => instance.is_string(),
+        _ => false,
+    };
+    if let Some(schema_type) = schema.get("type") {
+        let type_matches = match schema_type {
+            Value::String(schema_type) => matches_type(schema_type),
+            Value::Array(schema_types) => schema_types
+                .iter()
+                .filter_map(Value::as_str)
+                .any(matches_type),
+            _ => false,
+        };
+        if !type_matches {
+            return false;
+        }
+    }
+
+    if let Some(object) = instance.as_object() {
+        let properties = schema.get("properties").and_then(Value::as_object);
+        if let Some(required) = schema.get("required").and_then(Value::as_array) {
+            if required
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|field| !object.contains_key(field))
+            {
+                return false;
+            }
+        }
+        if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
+            let Some(properties) = properties else {
+                return object.is_empty();
+            };
+            if object.keys().any(|field| !properties.contains_key(field)) {
+                return false;
+            }
+        }
+        if let Some(properties) = properties {
+            for (field, value) in object {
+                if let Some(property_schema) = properties.get(field) {
+                    if !schema_accepts(document, property_schema, value) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    if let (Some(items), Some(array)) = (schema.get("items"), instance.as_array()) {
+        if array
+            .iter()
+            .any(|item| !schema_accepts(document, items, item))
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn valid_component_key(key: &str) -> bool {
+    !key.is_empty()
+        && key
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || ".-_".contains(character))
+}
+
+fn valid_response_code(code: &str) -> bool {
+    if code == "default" {
+        return true;
+    }
+    let bytes = code.as_bytes();
+    bytes.len() == 3
+        && matches!(bytes[0], b'1'..=b'5')
+        && ((bytes[1].is_ascii_digit() && bytes[2].is_ascii_digit())
+            || (bytes[1] == b'X' && bytes[2] == b'X'))
+}
+
+fn validate_content_schemas(errors: &mut Vec<String>, context: &str, content: &Value) {
+    let Some(content) = content.as_object() else {
+        errors.push(format!("{context} content must be an object"));
+        return;
+    };
+    if content.is_empty() {
+        errors.push(format!("{context} content must not be empty"));
+    }
+    for (media_type, media) in content {
+        if media.get("schema").and_then(Value::as_object).is_none() {
+            errors.push(format!("{context} media type {media_type} must define a schema"));
+        }
+    }
+}
+
+fn semantic_contract_errors(document: &Value) -> Vec<String> {
+    const METHODS: &[&str] = &["get", "put", "post", "delete", "options", "head", "patch", "trace"];
+
+    let mut errors = Vec::new();
+    let mut operation_ids = BTreeSet::new();
+    let Some(paths) = document.get("paths").and_then(Value::as_object) else {
+        return vec!["paths must be an object".to_string()];
+    };
+
+    if let Some(components) = document.get("components").and_then(Value::as_object) {
+        for (component_type, entries) in components {
+            let Some(entries) = entries.as_object() else {
+                errors.push(format!("components.{component_type} must be an object"));
+                continue;
+            };
+            for key in entries.keys() {
+                if !valid_component_key(key) {
+                    errors.push(format!("invalid component key {component_type}.{key}"));
+                }
+            }
+        }
+    }
+
+    for (path, path_item) in paths {
+        let Some(path_item) = path_item.as_object() else {
+            errors.push(format!("path item {path} must be an object"));
+            continue;
+        };
+        let template_parameters: BTreeSet<_> = template_parameters(path)
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+
+        for method in METHODS {
+            let Some(operation) = path_item.get(*method) else {
+                continue;
+            };
+            let context = format!("{} {}", method.to_ascii_uppercase(), path);
+            let Some(operation) = operation.as_object() else {
+                errors.push(format!("{context} operation must be an object"));
+                continue;
+            };
+
+            match operation.get("operationId").and_then(Value::as_str) {
+                Some(operation_id) if !operation_id.is_empty() => {
+                    if !operation_ids.insert(operation_id.to_string()) {
+                        errors.push(format!("duplicate operationId {operation_id}"));
+                    }
+                }
+                _ => errors.push(format!("{context} must define a non-empty operationId")),
+            }
+
+            let mut declared_path_parameters = BTreeSet::new();
+            for parameter in path_item
+                .get("parameters")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .chain(
+                    operation
+                        .get("parameters")
+                        .and_then(Value::as_array)
+                        .into_iter()
+                        .flatten(),
+                )
+            {
+                let parameter = resolved(document, parameter);
+                if parameter.get("in").and_then(Value::as_str) != Some("path") {
+                    continue;
+                }
+                let Some(name) = parameter.get("name").and_then(Value::as_str) else {
+                    errors.push(format!("{context} has a path parameter without a name"));
+                    continue;
+                };
+                if !declared_path_parameters.insert(name.to_string()) {
+                    errors.push(format!("{context} repeats path parameter {name}"));
+                }
+                if parameter.get("required") != Some(&Value::Bool(true)) {
+                    errors.push(format!("{context} path parameter {name} must be required"));
+                }
+                if parameter.get("allowReserved").is_some() {
+                    errors.push(format!(
+                        "{context} path parameter {name} must not use query-only allowReserved"
+                    ));
+                }
+            }
+            if declared_path_parameters != template_parameters {
+                errors.push(format!(
+                    "{context} path parameters {:?} do not exactly match template {:?}",
+                    declared_path_parameters, template_parameters
+                ));
+            }
+
+            if let Some(request_body) = operation.get("requestBody") {
+                let request_body = resolved(document, request_body);
+                match request_body.get("content") {
+                    Some(content) => validate_content_schemas(
+                        &mut errors,
+                        &format!("{context} request body"),
+                        content,
+                    ),
+                    None => errors.push(format!("{context} request body must define content")),
+                }
+            }
+
+            let Some(responses) = operation.get("responses").and_then(Value::as_object) else {
+                errors.push(format!("{context} must define a responses object"));
+                continue;
+            };
+            if responses.is_empty() {
+                errors.push(format!("{context} responses must not be empty"));
+            }
+            for (code, response) in responses {
+                if !valid_response_code(code) {
+                    errors.push(format!("{context} has invalid response code {code}"));
+                }
+                let response = resolved(document, response);
+                if response
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .is_none()
+                {
+                    errors.push(format!("{context} response {code} must have a description"));
+                }
+                if let Some(content) = response.get("content") {
+                    validate_content_schemas(
+                        &mut errors,
+                        &format!("{context} response {code}"),
+                        content,
+                    );
+                }
+            }
+        }
+    }
+
+    errors
+}
+
+#[test]
+fn openapi_contract_typed_parses_and_meets_project_requirements() {
+    assert!(
+        Path::new(CONTRACT_PATH).is_file(),
+        "the canonical OpenAPI contract must exist at {CONTRACT_PATH}"
+    );
+    let document = contract();
+
+    assert_eq!(document["openapi"], "3.1.0");
+    assert!(document["info"]["title"].is_string());
+    assert!(document["info"]["version"].is_string());
+    let paths = document["paths"]
+        .as_object()
+        .expect("paths must be an object");
+    let schemas = document["components"]["schemas"]
+        .as_object()
+        .expect("components.schemas must be an object");
+
+    let required_operations: BTreeMap<&str, &[&str]> = BTreeMap::from([
+        ("/api/book-thumbnails/{file}", &["get"] as &[_]),
+        ("/api/book/{checksum}", &["get", "delete"]),
+        ("/api/books", &["get"]),
+        ("/api/books/download/{path}", &["get"]),
+        ("/api/books/{collection}", &["get"]),
+        ("/api/control/ws", &["get"]),
+        ("/api/conversion", &["get"]),
+        ("/api/log", &["post"]),
+        ("/api/media", &["get"]),
+        ("/api/media/{media}", &["get", "delete", "post", "patch"]),
+        ("/api/remote", &["get"]),
+        ("/api/remote/control", &["post"]),
+        ("/api/remote/play", &["post"]),
+        ("/api/remote/ws", &["get"]),
+        ("/api/search/pirate", &["get"]),
+        ("/api/search/youtube", &["get"]),
+        ("/api/stream-audio/{audio_index}/{path}", &["get"]),
+        ("/api/stream/{path}", &["get"]),
+        ("/api/tasks", &["get", "post"]),
+        ("/api/tasks/{type}/{path}", &["delete"]),
+        ("/api/thumbnails/{path}", &["get"]),
+    ]);
+
+    for (path, methods) in required_operations {
+        let path_item = paths
+            .get(path)
+            .unwrap_or_else(|| panic!("missing required path {path}"));
+        for method in methods {
+            let operation = path_item
+                .get(method)
+                .unwrap_or_else(|| panic!("missing {method} operation for {path}"));
+            assert!(
+                operation["operationId"].is_string(),
+                "{method} {path} must define operationId"
+            );
+            assert!(
+                operation["responses"].is_object(),
+                "{method} {path} must define responses"
+            );
+
+            for parameter_name in template_parameters(path) {
+                let parameters = operation["parameters"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("{method} {path} must define path parameters"));
+                let parameter = parameters.iter().find(|parameter| {
+                    let parameter = parameter
+                        .get("$ref")
+                        .and_then(Value::as_str)
+                        .and_then(|reference| resolve_local_reference(&document, reference))
+                        .unwrap_or(parameter);
+                    parameter["in"] == "path" && parameter["name"] == parameter_name
+                });
+                let parameter = parameter.unwrap_or_else(|| {
+                    panic!("{method} {path} is missing path parameter {parameter_name}")
+                });
+                let parameter = parameter
+                    .get("$ref")
+                    .and_then(Value::as_str)
+                    .and_then(|reference| resolve_local_reference(&document, reference))
+                    .unwrap_or(parameter);
+                assert_eq!(parameter["required"], true);
+            }
+        }
+    }
+
+    for schema in [
+        "Response",
+        "ErrorResponse",
+        "TaskState",
+        "TaskListResults",
+        "SearchResults",
+        "CollectionItem",
+        "CollectionDetails",
+        "MediaItem",
+        "VideoDetails",
+        "BookMetadata",
+        "BookCollectionItem",
+        "BookCollectionDetails",
+        "BookDetails",
+    ] {
+        assert!(schemas.contains_key(schema), "missing reusable schema {schema}");
+    }
+
+    let mut references = Vec::new();
+    visit_references(&document, &mut |reference| {
+        references.push(reference.to_string())
+    });
+    assert!(
+        !references.is_empty(),
+        "contract should reuse component references"
+    );
+    for reference in references {
+        assert!(
+            reference.starts_with("#/"),
+            "external reference {reference} is not self-contained"
+        );
+        assert!(
+            resolve_local_reference(&document, &reference).is_some(),
+            "unresolved OpenAPI reference {reference}"
+        );
+    }
+
+    assert_eq!(
+        schemas["BookDetails"]["properties"]["checksum"]["type"],
+        "string"
+    );
+    assert_eq!(
+        schemas["VideoDetails"]["properties"]["checksum"]["type"],
+        "string"
+    );
+
+    for (path, methods, parameter_name) in [
+        ("/api/tasks/{type}/{path}", &["delete"] as &[_], "path"),
+        (
+            "/api/media/{media}",
+            &["get", "delete", "post", "patch"] as &[_],
+            "media",
+        ),
+        ("/api/books/{collection}", &["get"] as &[_], "collection"),
+        ("/api/books/download/{path}", &["get"] as &[_], "path"),
+        (
+            "/api/stream-audio/{audio_index}/{path}",
+            &["get"] as &[_],
+            "path",
+        ),
+        ("/api/stream/{path}", &["get"] as &[_], "path"),
+        ("/api/thumbnails/{path}", &["get"] as &[_], "path"),
+    ] {
+        for method in methods {
+            let operation = paths[path][method]
+                .as_object()
+                .expect("wildcard route must have an operation");
+            let parameter = operation["parameters"]
+                .as_array()
+                .expect("wildcard route must define parameters")
+                .iter()
+                .find(|parameter| parameter["name"] == parameter_name)
+                .expect("wildcard parameter must be documented");
+            let description = parameter["description"]
+                .as_str()
+                .expect("wildcard parameter must have a description")
+                .to_ascii_lowercase();
+            assert!(description.contains("url-encoded"));
+            assert!(description.contains("nested path"));
+        }
+    }
+
+    let media_schema = serde_json::to_string(&schemas["MediaItem"]).unwrap();
+    assert!(media_schema.contains("VideoDetails"));
+    assert!(media_schema.contains("CollectionDetails"));
+    assert!(
+        !media_schema.to_ascii_lowercase().contains("book"),
+        "/api/media's MediaItem schema must remain video-only"
+    );
+    assert_eq!(
+        paths["/api/media"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+            ["$ref"],
+        "#/components/schemas/MediaItem"
+    );
+}
+
+#[test]
+fn serve_dir_thumbnail_route_is_greedy_and_path_parameters_are_standards_compliant() {
+    let document = contract();
+    let paths = document["paths"].as_object().unwrap();
+    assert!(paths.contains_key("/api/thumbnails/{path}"));
+    assert!(!paths.contains_key("/api/thumbnails/{file}"));
+
+    let parameter = &paths["/api/thumbnails/{path}"]["get"]["parameters"][0];
+    let description = parameter["description"]
+        .as_str()
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(description.contains("greedy nested path"));
+    assert!(description.contains("url-encoded"));
+    assert!(description.contains("decoded"));
+
+    let mut path_parameters_with_allow_reserved = Vec::new();
+    fn find_invalid_path_parameters(value: &Value, invalid: &mut Vec<String>) {
+        match value {
+            Value::Object(object) => {
+                if object.get("in").and_then(Value::as_str) == Some("path")
+                    && object.contains_key("allowReserved")
+                {
+                    invalid.push(
+                        object
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or("<unnamed>")
+                            .to_string(),
+                    );
+                }
+                for child in object.values() {
+                    find_invalid_path_parameters(child, invalid);
+                }
+            }
+            Value::Array(array) => {
+                for child in array {
+                    find_invalid_path_parameters(child, invalid);
+                }
+            }
+            _ => {}
+        }
+    }
+    find_invalid_path_parameters(&document, &mut path_parameters_with_allow_reserved);
+    assert!(
+        path_parameters_with_allow_reserved.is_empty(),
+        "path parameters must not use query-only allowReserved: {:?}",
+        path_parameters_with_allow_reserved
+    );
+}
+
+#[test]
+fn remote_request_schemas_accept_runtime_valid_serde_payloads() {
+    let document = contract();
+    let schemas = document["components"]["schemas"].as_object().unwrap();
+
+    let command_fixtures = [
+        serde_json::json!({
+            "message": {
+                "State": {
+                    "collection": "Series",
+                    "video": "episode.webm",
+                    "videoId": "42",
+                    "paused": false
+                }
+            }
+        }),
+        serde_json::json!({
+            "message": {
+                "State": {
+                    "currentTime": null,
+                    "duration": null,
+                    "collection": "Series",
+                    "video": "episode.webm",
+                    "videoId": "42",
+                    "paused": false,
+                    "currentSubtitleTrack": null
+                }
+            }
+        }),
+        serde_json::json!({"message": {"SetSubtitleTrack": {}}}),
+        serde_json::json!({
+            "message": {
+                "Play": {
+                    "videoId": "42",
+                    "url": "/api/stream/episode.webm",
+                    "collection": "",
+                    "video": "episode.webm",
+                    "width": 1920,
+                    "height": 1080,
+                    "aspectWidth": 16,
+                    "aspectHeight": 9
+                }
+            }
+        }),
+        serde_json::json!({
+            "message": {
+                "Play": {
+                    "videoId": "42",
+                    "url": "/api/stream/episode.webm",
+                    "collection": "",
+                    "video": "episode.webm",
+                    "width": 1920,
+                    "height": 1080,
+                    "aspectWidth": 16,
+                    "aspectHeight": 9,
+                    "metadata": null
+                }
+            }
+        }),
+        serde_json::json!({"message": {"SetSubtitleTrack": {"trackId": null}}}),
+    ];
+    for fixture in command_fixtures {
+        serde_json::from_value::<Command>(fixture.clone())
+            .expect("fixture must be accepted by runtime Command deserialization");
+        assert!(
+            schema_accepts(&document, &schemas["Command"], &fixture),
+            "Command schema rejected runtime-valid fixture: {fixture}"
+        );
+    }
+
+    let play_request = serde_json::json!({
+        "collection": "",
+        "video": "episode.webm",
+        "width": 1920,
+        "height": 1080,
+        "aspectWidth": 16,
+        "aspectHeight": 9,
+        "videoId": "42"
+    });
+    serde_json::from_value::<PlayRequest>(play_request.clone())
+        .expect("fixture must be accepted by runtime PlayRequest deserialization");
+    assert!(
+        schema_accepts(&document, &schemas["PlayRequest"], &play_request),
+        "PlayRequest schema rejected runtime-valid fixture"
+    );
+
+    let play_request_with_null_metadata = serde_json::json!({
+        "collection": "",
+        "video": "episode.webm",
+        "width": 1920,
+        "height": 1080,
+        "aspectWidth": 16,
+        "aspectHeight": 9,
+        "videoId": "42",
+        "metadata": null
+    });
+    serde_json::from_value::<PlayRequest>(play_request_with_null_metadata.clone())
+        .expect("null metadata must be accepted by runtime PlayRequest deserialization");
+    assert!(schema_accepts(
+        &document,
+        &schemas["PlayRequest"],
+        &play_request_with_null_metadata
+    ));
+}
+
+#[test]
+fn inbound_last_state_schema_accepts_defaulted_video_details() {
+    let document = contract();
+    let command_schema = &document["components"]["schemas"]["Command"];
+    let fixtures = [
+        serde_json::json!({"message": {"LastState": {}}}),
+        serde_json::json!({
+            "message": {
+                "LastState": {
+                    "video": "episode.mkv",
+                    "checksum": "42"
+                }
+            }
+        }),
+        serde_json::json!({
+            "ignoredCommandField": true,
+            "message": {
+                "LastState": {
+                    "ignoredVideoField": true,
+                    "series": {
+                        "seriesTitle": "Example",
+                        "season": "1",
+                        "episode": "2",
+                        "episodeTitle": "Nested defaults",
+                        "ignoredSeriesField": true
+                    },
+                    "metadata": {
+                        "duration": 120.0,
+                        "width": 1920,
+                        "height": 1080,
+                        "aspectWidth": 16,
+                        "aspectHeight": 9,
+                        "audioTracks": 1,
+                        "audioTrackList": [{
+                            "id": 0,
+                            "language": "eng",
+                            "title": null,
+                            "ignoredTrackField": true
+                        }],
+                        "subtitleTracks": null,
+                        "ignoredMetadataField": true
+                    }
+                }
+            }
+        }),
+    ];
+
+    for fixture in fixtures {
+        serde_json::from_value::<Command>(fixture.clone())
+            .expect("runtime Command deserialization accepts defaulted VideoDetails");
+        assert!(
+            schema_accepts(&document, command_schema, &fixture),
+            "inbound Command schema rejected runtime-valid LastState: {fixture}"
+        );
+    }
+}
+
+#[test]
+fn audio_stream_index_matches_the_runtime_u32_extractor() {
+    let document = contract();
+    let parameters = document["paths"]["/api/stream-audio/{audio_index}/{path}"]["get"]
+        ["parameters"]
+        .as_array()
+        .unwrap();
+    let audio_index = parameters
+        .iter()
+        .find(|parameter| parameter["name"] == "audio_index")
+        .expect("audio stream route must document audio_index");
+    assert_eq!(audio_index["schema"]["minimum"], 0);
+    assert_eq!(audio_index["schema"]["maximum"], 4_294_967_295_u64);
+}
+
+#[test]
+fn security_contract_matches_restrict_access_router_layering() {
+    const METHODS: &[&str] = &["get", "put", "post", "delete", "options", "head", "patch", "trace"];
+    const UNPROTECTED_PATHS: &[&str] = &[
+        "/api/stream/{path}",
+        "/api/stream-audio/{audio_index}/{path}",
+        "/api/thumbnails/{path}",
+        "/api/book-thumbnails/{file}",
+    ];
+
+    let document = contract();
+    let security_schemes = document["components"]["securitySchemes"]
+        .as_object()
+        .expect("restrict_access authentication schemes must be documented");
+    assert_eq!(security_schemes["HttpBasicAuth"]["type"], "http");
+    assert_eq!(security_schemes["HttpBasicAuth"]["scheme"], "basic");
+    assert_eq!(security_schemes["QueryAuth"]["type"], "apiKey");
+    assert_eq!(security_schemes["QueryAuth"]["in"], "query");
+    assert_eq!(security_schemes["QueryAuth"]["name"], "auth");
+    for scheme in ["HttpBasicAuth", "QueryAuth"] {
+        let description = security_schemes[scheme]["description"]
+            .as_str()
+            .expect("authentication schemes need runtime-grounded descriptions");
+        assert!(description.contains("AUTH_CREDENTIALS"));
+    }
+
+    let security = document["security"]
+        .as_array()
+        .expect("protected routes must inherit security requirements");
+    assert_eq!(security.len(), 2);
+    assert!(!security
+        .iter()
+        .any(|requirement| requirement == &serde_json::json!({})));
+    assert!(security
+        .iter()
+        .any(|requirement| requirement == &serde_json::json!({"HttpBasicAuth": []})));
+    assert!(security
+        .iter()
+        .any(|requirement| requirement == &serde_json::json!({"QueryAuth": []})));
+    let auth_description = document["info"]["description"]
+        .as_str()
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(auth_description.contains("localhost"));
+    assert!(auth_description.contains("192.168"));
+    assert!(auth_description.contains("x-real-ip"));
+    assert!(auth_description.contains("x-forwarded-for"));
+
+    let unauthorized = &document["components"]["responses"]["UnauthorizedResponse"];
+    assert_eq!(
+        unauthorized["headers"]["WWW-Authenticate"]["schema"]["type"],
+        "string"
+    );
+    assert_eq!(
+        unauthorized["headers"]["WWW-Authenticate"]["example"],
+        "Basic realm=\"tvserver\""
+    );
+
+    for (path, path_item) in document["paths"].as_object().unwrap() {
+        for method in METHODS {
+            let Some(operation) = path_item.get(*method) else {
+                continue;
+            };
+            if UNPROTECTED_PATHS.contains(&path.as_str()) {
+                assert_eq!(
+                    operation["security"],
+                    serde_json::json!([]),
+                    "{method} {path} must override global security because its router is unprotected"
+                );
+                assert!(operation["responses"].get("401").is_none());
+            } else {
+                assert_eq!(
+                    operation["responses"]["401"]["$ref"],
+                    "#/components/responses/UnauthorizedResponse",
+                    "{method} {path} is layered with restrict_access and must document 401"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn stream_responses_cover_all_video_content_types() {
+    let document = contract();
+    for status in ["200", "206"] {
+        let content = document["paths"]["/api/stream/{path}"]["get"]["responses"][status]
+            ["content"]
+            .as_object()
+            .unwrap();
+        let content_types: BTreeSet<_> = content.keys().map(String::as_str).collect();
+        assert_eq!(
+            content_types,
+            BTreeSet::from(["video/*", "application/octet-stream"]),
+            "stream response {status} must cover every ServeDir video MIME plus its fallback"
+        );
+    }
+}
+
+#[test]
+fn search_query_schema_allows_the_empty_string_accepted_by_the_handler() {
+    let document = contract();
+    let query = &document["components"]["parameters"]["SearchQuery"]["schema"];
+    assert!(
+        query.get("minLength").and_then(Value::as_u64).unwrap_or(0) == 0,
+        "the handler accepts q=, so the contract must not require a non-empty query"
+    );
+}
+
+#[test]
+fn contract_passes_project_semantic_openapi_checks() {
+    let document = contract();
+    let errors = semantic_contract_errors(&document);
+    assert!(
+        errors.is_empty(),
+        "OpenAPI semantic validation failed:\n{}",
+        errors.join("\n")
+    );
+}
+
+#[test]
+fn project_semantic_checks_reject_representative_contract_defects() {
+    let mut document = contract();
+
+    document["paths"]["/api/books"]["get"]["operationId"] = Value::String("listTasks".to_string());
+    document["paths"]["/api/books/{collection}"]["get"]["parameters"] = Value::Array(Vec::new());
+    document["paths"]["/api/log"]["post"]["responses"]["200"]
+        .as_object_mut()
+        .unwrap()
+        .remove("description");
+    let invalid_response = document["paths"]["/api/log"]["post"]["responses"]["200"].clone();
+    document["paths"]["/api/log"]["post"]["responses"]
+        .as_object_mut()
+        .unwrap()
+        .insert("099".to_string(), invalid_response);
+    document["paths"]["/api/tasks"]["post"]["requestBody"]["content"]["application/json"]
+        .as_object_mut()
+        .unwrap()
+        .remove("schema");
+    let response_schema = document["components"]["schemas"]["Response"].clone();
+    document["components"]["schemas"]
+        .as_object_mut()
+        .unwrap()
+        .insert("invalid component key".to_string(), response_schema);
+
+    let errors = semantic_contract_errors(&document).join("\n");
+    for expected in [
+        "duplicate operationId listTasks",
+        "path parameters {} do not exactly match template {\"collection\"}",
+        "response 200 must have a description",
+        "invalid response code 099",
+        "media type application/json must define a schema",
+        "invalid component key schemas.invalid component key",
+    ] {
+        assert!(
+            errors.contains(expected),
+            "semantic checks did not report {expected:?}; errors were:\n{errors}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add the canonical OpenAPI 3.1 contract for all frontend-facing REST, static media/book, diagnostic, and WebSocket upgrade routes
- model video-only media responses, book collections/details, remote-control requests, authentication boundaries, wildcard paths, and error responses from the runtime implementation
- validate the contract with pinned `roas` semantic validation, typed `oas3` parsing, project-specific route/schema checks, mutation tests, and runtime Serde fixtures

## Validation

- `env NO_PROXY='*' make test` — 266 library tests passed, 4 ignored; 31 integration tests passed
- `cargo check`
- `cargo check --no-default-features --features webserver`
- `git diff --check origin/spec/ebook-support..HEAD`
- independent task and whole-change reviews approved with no remaining findings

The existing `DEFAULT_MIGRATIONS_DIR` dead-code warning remains unchanged.

Closes #61