### PR TITLE
Complete ebook support final verification

### DIFF
--- a/src/domain/config.rs
+++ b/src/domain/config.rs
@@ -22,7 +22,6 @@ const TELEGRAM_CHAT_ID: &str = "TELEGRAM_CHAT_ID";
 const AUTH_CREDENTIALS: &str = "AUTH_CREDENTIALS";
 //  Defaults
 const DEFAULT_DATABASE_URL: &str = "sqlite::memory:";
-const DEFAULT_MIGRATIONS_DIR: &str = "./migrations";
 const DEFAULT_CLIENT_DIR: &str = "client";
 const DEFAULT_PB_URL: &str = "https://apibay.org";
 const DEFAULT_DELAY_REAPING_TASKS_SECS: i64 = 60;


### PR DESCRIPTION
## Summary

- complete the remaining final-verification task from the ebook support plan
- remove the stale `DEFAULT_MIGRATIONS_DIR` constant so warning-denied builds are clean
- confirm the existing Tasks 1–13 implementation satisfies the approved plan and spec

## Why

Tasks 1–13 were already merged into `spec/ebook-support`. The final verification pass found one dead-code warning from a constant no longer used by the live migration-directory resolver. Removing it is behavior-neutral and allows both Tauri and webserver builds to pass with warnings denied.

## Impact

No runtime behavior or API contract changes. Migration lookup continues to use `DATABASE_MIGRATION_DIR`, then `migrations` and `src-tauri/migrations`.

## Validation

- `RUSTFLAGS='-D warnings' cargo check`
- `RUSTFLAGS='-D warnings' cargo check --no-default-features --features webserver`
- `RUSTFLAGS='-D warnings' cargo check --no-default-features --features webserver,pdf-thumbnails`
- `make test` — 266 unit tests and 33 integration tests passed, 0 failed
- OpenAPI contract tests — 13 passed
- branch ancestry and `git diff --check` verified against `origin/spec/ebook-support`
- task-scoped and final whole-branch reviews reported no findings

Closes #48