### PR TITLE
Restore byte ranges for capability-backed books

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ tauri-build = { version = "2.6.3", features = [], optional = true }
 oas3 = { version = "0.22", features = ["yaml-spec"] }
 roas = { version = "=0.17.2", default-features = false, features = ["v3_1"] }
 serde_yaml = "0.9"
+tower = { version = "0.5", features = ["util"] }
 
 [profile.release]
 codegen-units = 1 # Allows LLVM to perform better optimization.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "chrono", "sqlite"
 thiserror = "1.0.40"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = "0.7.4"
-tower-http = { version = "0.6.1", features = ["fs", "trace", "cors"] }
+tower-http = { version = "0.7.0", features = ["fs", "trace", "cors"] }
 titlecase = "2.2.1"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -377,6 +377,9 @@ paths:
               schema:
                 type: string
                 const: bytes
+            Last-Modified:
+              schema:
+                type: string
             Content-Length:
               schema:
                 type: integer
@@ -391,6 +394,9 @@ paths:
               schema:
                 type: string
                 const: bytes
+            Last-Modified:
+              schema:
+                type: string
             Content-Length:
               schema:
                 type: integer
@@ -401,10 +407,14 @@ paths:
           content:
             application/pdf: {}
             application/epub+zip: {}
+        '304':
+          $ref: '#/components/responses/ServeDirNotModifiedResponse'
         '400':
           $ref: '#/components/responses/BadRequestTextResponse'
         '404':
           description: Missing, unsupported, or rejected path; the response has no body.
+        '412':
+          $ref: '#/components/responses/ServeDirPreconditionFailedResponse'
         '416':
           description: Requested range is invalid, unsatisfiable, or contains multiple ranges.
           headers:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -363,10 +363,20 @@ paths:
           description: Greedy nested path suffix relative to BOOK_DIR; clients send each segment URL-encoded and Axum passes the decoded value.
           schema:
             type: string
+        - name: Range
+          in: header
+          required: false
+          description: A single RFC 7233 byte range, including closed, open-ended, or suffix form.
+          schema:
+            type: string
       responses:
         '200':
           description: Book file
           headers:
+            Accept-Ranges:
+              schema:
+                type: string
+                const: bytes
             Content-Length:
               schema:
                 type: integer
@@ -374,10 +384,40 @@ paths:
           content:
             application/pdf: {}
             application/epub+zip: {}
+        '206':
+          description: One satisfiable byte range of the book file.
+          headers:
+            Accept-Ranges:
+              schema:
+                type: string
+                const: bytes
+            Content-Length:
+              schema:
+                type: integer
+                minimum: 0
+            Content-Range:
+              schema:
+                type: string
+          content:
+            application/pdf: {}
+            application/epub+zip: {}
         '400':
           $ref: '#/components/responses/BadRequestTextResponse'
         '404':
           description: Missing, unsupported, or rejected path; the response has no body.
+        '416':
+          description: Requested range is invalid, unsatisfiable, or contains multiple ranges.
+          headers:
+            Accept-Ranges:
+              schema:
+                type: string
+                const: bytes
+            Content-Range:
+              schema:
+                type: string
+          content:
+            application/pdf: {}
+            application/epub+zip: {}
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '500':

--- a/src/entrypoints/capability_file_service.rs
+++ b/src/entrypoints/capability_file_service.rs
@@ -1,0 +1,246 @@
+use std::{
+    ffi::OsString,
+    future::{ready, Future, Ready},
+    io,
+    path::{Component, Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::SystemTime,
+};
+
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt, OpenOptionsMaybeDirExt};
+use cap_std::fs::{Dir, OpenOptions};
+use tokio::io::{AsyncRead, AsyncSeek, ReadBuf};
+use tower_http::services::fs::{Backend, File, Metadata};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum StaticFilePolicy {
+    BookDownload,
+    BookThumbnail,
+}
+
+impl StaticFilePolicy {
+    fn accepts(self, components: &[OsString]) -> bool {
+        let Some(extension) = components
+            .last()
+            .and_then(|component| Path::new(component).extension())
+            .and_then(|extension| extension.to_str())
+        else {
+            return false;
+        };
+
+        match self {
+            Self::BookDownload => {
+                extension.eq_ignore_ascii_case("epub") || extension.eq_ignore_ascii_case("pdf")
+            }
+            Self::BookThumbnail => components.len() == 1 && extension.eq_ignore_ascii_case("jpg"),
+        }
+    }
+}
+
+fn not_found(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::NotFound, message)
+}
+
+fn normal_components(path: &Path, policy: StaticFilePolicy) -> io::Result<Vec<OsString>> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir if components.is_empty() => {}
+            Component::Normal(component) => components.push(component.to_os_string()),
+            Component::CurDir
+            | Component::ParentDir
+            | Component::Prefix(_)
+            | Component::RootDir => {
+                return Err(not_found("static file path must be relative"));
+            }
+        }
+    }
+
+    if components.is_empty() || !policy.accepts(&components) {
+        return Err(not_found("static file path rejected by policy"));
+    }
+    Ok(components)
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct CapabilityBackend {
+    root: Arc<Dir>,
+    policy: StaticFilePolicy,
+}
+
+impl CapabilityBackend {
+    pub(super) fn new(root: Arc<Dir>, policy: StaticFilePolicy) -> Self {
+        Self { root, policy }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct CapabilityMetadata {
+    len: u64,
+    modified: SystemTime,
+}
+
+impl Metadata for CapabilityMetadata {
+    fn is_dir(&self) -> bool {
+        false
+    }
+
+    fn modified(&self) -> io::Result<SystemTime> {
+        Ok(self.modified)
+    }
+
+    fn len(&self) -> u64 {
+        self.len
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct CapabilityFile {
+    file: tokio::fs::File,
+    metadata: CapabilityMetadata,
+}
+
+impl AsyncRead for CapabilityFile {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.file).poll_read(cx, buffer)
+    }
+}
+
+impl AsyncSeek for CapabilityFile {
+    fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
+        Pin::new(&mut self.file).start_seek(position)
+    }
+
+    fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+        Pin::new(&mut self.file).poll_complete(cx)
+    }
+}
+
+impl File for CapabilityFile {
+    type Metadata = CapabilityMetadata;
+    type MetadataFuture<'a> = Ready<io::Result<Self::Metadata>>;
+
+    fn metadata(&self) -> Self::MetadataFuture<'_> {
+        ready(Ok(self.metadata.clone()))
+    }
+}
+
+fn open_regular_file(
+    root: &Dir,
+    components: &[OsString],
+) -> io::Result<(cap_std::fs::File, CapabilityMetadata)> {
+    let mut current = root.try_clone()?;
+    for component in &components[..components.len() - 1] {
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            .maybe_dir(true)
+            .follow(FollowSymlinks::No);
+        let child = current.open_with(Path::new(component), &options)?;
+        if !child.metadata()?.is_dir() {
+            return Err(not_found("static file parent is not a directory"));
+        }
+        current = Dir::from_std_file(child.into_std());
+    }
+
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = current.open_with(
+        Path::new(components.last().expect("validated non-empty components")),
+        &options,
+    )?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(not_found("static file is not a regular file"));
+    }
+    Ok((
+        file,
+        CapabilityMetadata {
+            len: metadata.len(),
+            modified: metadata.modified()?.into_std(),
+        },
+    ))
+}
+
+impl Backend for CapabilityBackend {
+    type File = CapabilityFile;
+    type Metadata = CapabilityMetadata;
+    type OpenFuture = Pin<Box<dyn Future<Output = io::Result<Self::File>> + Send>>;
+    type MetadataFuture = Pin<Box<dyn Future<Output = io::Result<Self::Metadata>> + Send>>;
+
+    fn open(&self, path: PathBuf) -> Self::OpenFuture {
+        let root = self.root.clone();
+        let policy = self.policy;
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let components = normal_components(&path, policy)?;
+                let (file, metadata) = open_regular_file(&root, &components)?;
+                Ok(CapabilityFile {
+                    file: tokio::fs::File::from_std(file.into_std()),
+                    metadata,
+                })
+            })
+            .await
+            .map_err(io::Error::other)?
+        })
+    }
+
+    fn metadata(&self, path: PathBuf) -> Self::MetadataFuture {
+        let root = self.root.clone();
+        let policy = self.policy;
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let components = normal_components(&path, policy)?;
+                let (_, metadata) = open_regular_file(&root, &components)?;
+                Ok(metadata)
+            })
+            .await
+            .map_err(io::Error::other)?
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn book_download_policy_accepts_nested_epub_and_pdf_paths() {
+        assert_eq!(
+            normal_components(Path::new("./Fiction/Dune.EPUB"), StaticFilePolicy::BookDownload)
+                .unwrap(),
+            [OsString::from("Fiction"), OsString::from("Dune.EPUB")]
+        );
+        assert!(normal_components(
+            Path::new("./Reference/manual.PDF"),
+            StaticFilePolicy::BookDownload
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn static_policies_reject_wrong_extensions_and_thumbnail_nesting() {
+        for path in ["./notes.txt", "./book.epub.exe", "./collection"] {
+            assert!(normal_components(Path::new(path), StaticFilePolicy::BookDownload).is_err());
+        }
+        assert!(
+            normal_components(Path::new("./cover.JPG"), StaticFilePolicy::BookThumbnail).is_ok()
+        );
+        for path in ["./nested/cover.jpg", "./cover.png"] {
+            assert!(normal_components(Path::new(path), StaticFilePolicy::BookThumbnail).is_err());
+        }
+    }
+
+    #[test]
+    fn static_policies_reject_non_relative_components() {
+        for path in ["../secret.epub", "/secret.epub"] {
+            assert!(normal_components(Path::new(path), StaticFilePolicy::BookDownload).is_err());
+        }
+    }
+}

--- a/src/entrypoints/capability_file_service.rs
+++ b/src/entrypoints/capability_file_service.rs
@@ -43,6 +43,10 @@ fn not_found(message: &'static str) -> io::Error {
     io::Error::new(io::ErrorKind::NotFound, message)
 }
 
+fn hidden_path_error(_: io::Error) -> io::Error {
+    not_found("static file not found")
+}
+
 fn normal_components(path: &Path, policy: StaticFilePolicy) -> io::Result<Vec<OsString>> {
     let mut components = Vec::new();
     for component in path.components() {
@@ -142,8 +146,10 @@ fn open_regular_file(
             .read(true)
             .maybe_dir(true)
             .follow(FollowSymlinks::No);
-        let child = current.open_with(Path::new(component), &options)?;
-        if !child.metadata()?.is_dir() {
+        let child = current
+            .open_with(Path::new(component), &options)
+            .map_err(hidden_path_error)?;
+        if !child.metadata().map_err(hidden_path_error)?.is_dir() {
             return Err(not_found("static file parent is not a directory"));
         }
         current = Dir::from_std_file(child.into_std());
@@ -151,11 +157,13 @@ fn open_regular_file(
 
     let mut options = OpenOptions::new();
     options.read(true).follow(FollowSymlinks::No);
-    let file = current.open_with(
-        Path::new(components.last().expect("validated non-empty components")),
-        &options,
-    )?;
-    let metadata = file.metadata()?;
+    let file = current
+        .open_with(
+            Path::new(components.last().expect("validated non-empty components")),
+            &options,
+        )
+        .map_err(hidden_path_error)?;
+    let metadata = file.metadata().map_err(hidden_path_error)?;
     if !metadata.is_file() {
         return Err(not_found("static file is not a regular file"));
     }
@@ -210,6 +218,34 @@ impl Backend for CapabilityBackend {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    struct TestRoot(PathBuf);
+
+    #[cfg(unix)]
+    impl TestRoot {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "tvserver-capability-file-service-{}-{}",
+                std::process::id(),
+                rand::random::<u64>()
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn backend(&self) -> CapabilityBackend {
+            let root = Dir::open_ambient_dir(&self.0, cap_std::ambient_authority()).unwrap();
+            CapabilityBackend::new(Arc::new(root), StaticFilePolicy::BookDownload)
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for TestRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
     #[test]
     fn book_download_policy_accepts_nested_epub_and_pdf_paths() {
         assert_eq!(
@@ -242,5 +278,50 @@ mod tests {
         for path in ["../secret.epub", "/secret.epub"] {
             assert!(normal_components(Path::new(path), StaticFilePolicy::BookDownload).is_err());
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn backend_rejects_symlinked_parent_with_not_found() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestRoot::new();
+        let outside = root.0.join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("Dune.epub"), b"book").unwrap();
+        symlink(&outside, root.0.join("Fiction")).unwrap();
+        let backend = root.backend();
+        let path = PathBuf::from("Fiction/Dune.epub");
+
+        assert_eq!(
+            backend.open(path.clone()).await.unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            backend.metadata(path).await.unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn backend_rejects_final_symlink_with_not_found() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestRoot::new();
+        let target = root.0.join("target.epub");
+        std::fs::write(&target, b"book").unwrap();
+        symlink(&target, root.0.join("Dune.epub")).unwrap();
+        let backend = root.backend();
+        let path = PathBuf::from("Dune.epub");
+
+        assert_eq!(
+            backend.open(path.clone()).await.unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            backend.metadata(path).await.unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
     }
 }

--- a/src/entrypoints/capability_file_service.rs
+++ b/src/entrypoints/capability_file_service.rs
@@ -83,7 +83,7 @@ impl CapabilityBackend {
 #[derive(Clone, Debug)]
 pub(super) struct CapabilityMetadata {
     len: u64,
-    modified: SystemTime,
+    modified: Option<SystemTime>,
 }
 
 impl Metadata for CapabilityMetadata {
@@ -92,7 +92,9 @@ impl Metadata for CapabilityMetadata {
     }
 
     fn modified(&self) -> io::Result<SystemTime> {
-        Ok(self.modified)
+        self.modified.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Unsupported, "modification time is unavailable")
+        })
     }
 
     fn len(&self) -> u64 {
@@ -171,7 +173,7 @@ fn open_regular_file(
         file,
         CapabilityMetadata {
             len: metadata.len(),
-            modified: metadata.modified()?.into_std(),
+            modified: metadata.modified().ok().map(|modified| modified.into_std()),
         },
     ))
 }
@@ -278,6 +280,21 @@ mod tests {
         for path in ["../secret.epub", "/secret.epub"] {
             assert!(normal_components(Path::new(path), StaticFilePolicy::BookDownload).is_err());
         }
+    }
+
+    #[test]
+    fn metadata_without_modified_time_retains_length_and_reports_modified_error() {
+        let metadata = CapabilityMetadata {
+            len: 42,
+            modified: None,
+        };
+
+        assert_eq!(metadata.len(), 42);
+        assert!(!metadata.is_dir());
+        assert_eq!(
+            metadata.modified().unwrap_err().kind(),
+            io::ErrorKind::Unsupported
+        );
     }
 
     #[cfg(unix)]

--- a/src/entrypoints/mod.rs
+++ b/src/entrypoints/mod.rs
@@ -1,5 +1,7 @@
 pub mod api;
 mod book_runtime;
+#[cfg(feature = "webserver")]
+mod capability_file_service;
 mod context;
 mod tvserver;
 #[cfg(feature = "webserver")]

--- a/src/entrypoints/webserver.rs
+++ b/src/entrypoints/webserver.rs
@@ -17,7 +17,10 @@ use crate::services::{setup_logging, TVSERVER_LOG};
 use axum::{
     body::Body,
     extract::Request,
-    http::{HeaderName, HeaderValue, StatusCode},
+    http::{
+        header::{IF_RANGE, RANGE},
+        HeaderName, HeaderValue, Method, StatusCode,
+    },
     middleware,
     middleware::Next,
     response::Response,
@@ -64,6 +67,16 @@ async fn empty_unsatisfiable_range_body(request: Request<Body>, next: Next) -> R
     response
 }
 
+async fn conservatively_normalize_static_file_request(
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    if request.method() != Method::GET || request.headers().contains_key(IF_RANGE) {
+        request.headers_mut().remove(RANGE);
+    }
+    next.run(request).await
+}
+
 pub async fn run_webserver(port: Option<u16>) -> anyhow::Result<()> {
     setup_logging(TVSERVER_LOG);
 
@@ -99,32 +112,39 @@ pub fn build_http_router(context: crate::entrypoints::Context) -> anyhow::Result
         .fallback_service(ServeDir::new(get_client_path("newapp")));
 
     // Unprotected routes: streaming and thumbnails (need external access for casting)
+    let video_stream_service = Router::new()
+        .fallback_service(ServeDir::new(&movie_dir))
+        .layer(middleware::from_fn(conservatively_normalize_static_file_request));
+
     let mut unprotected_routes = Router::new()
         .route(
             "/api/stream-audio/{audio_index}/{*path}",
             get(crate::entrypoints::api::stream_audio),
         )
-        .nest_service("/api/stream", ServeDir::new(&movie_dir))
+        .nest_service("/api/stream", video_stream_service)
         .nest_service("/api/thumbnails", ServeDir::new(get_thumbnail_dir(&movie_dir)));
 
     let (book_download_routes, book_thumbnail_routes) = match book_static_roots {
         Some(roots) => (
-            Router::new().route_service(
-                "/{*path}",
-                ServeDir::with_backend(
-                    "",
-                    CapabilityBackend::new(roots.downloads, StaticFilePolicy::BookDownload),
-                ),
-            )
-            .layer(middleware::from_fn(empty_unsatisfiable_range_body)),
-            Router::new().route_service(
-                "/{file}",
-                ServeDir::with_backend(
-                    "",
-                    CapabilityBackend::new(roots.thumbnails, StaticFilePolicy::BookThumbnail),
-                ),
-            )
-            .layer(middleware::from_fn(empty_unsatisfiable_range_body)),
+            Router::new()
+                .route_service(
+                    "/{*path}",
+                    ServeDir::with_backend(
+                        "",
+                        CapabilityBackend::new(roots.downloads, StaticFilePolicy::BookDownload),
+                    ),
+                )
+                .layer(middleware::from_fn(empty_unsatisfiable_range_body))
+                .layer(middleware::from_fn(conservatively_normalize_static_file_request)),
+            Router::new()
+                .route_service(
+                    "/{file}",
+                    ServeDir::with_backend(
+                        "",
+                        CapabilityBackend::new(roots.thumbnails, StaticFilePolicy::BookThumbnail),
+                    ),
+                )
+                .layer(middleware::from_fn(empty_unsatisfiable_range_body)),
         ),
         None => (
             Router::new().route("/{*path}", get(serve_unavailable_book_static)),

--- a/src/entrypoints/webserver.rs
+++ b/src/entrypoints/webserver.rs
@@ -6,36 +6,24 @@
 
 extern crate core;
 
-use std::{
-    ffi::OsString,
-    net::SocketAddr,
-    path::{Component, Path},
-    sync::Arc,
-};
+use std::{net::SocketAddr, sync::Arc};
 
 use crate::adaptors::restrict_access;
-use crate::domain::config::{
-    get_client_path, get_movie_dir, get_thumbnail_dir,
-};
+use crate::domain::config::{get_client_path, get_movie_dir, get_thumbnail_dir};
+use crate::entrypoints::capability_file_service::{CapabilityBackend, StaticFilePolicy};
 use crate::entrypoints::register;
 use crate::entrypoints::TVServer;
 use crate::services::{setup_logging, TVSERVER_LOG};
-use anyhow::anyhow;
 use axum::{
     body::Body,
-    extract::{Path as AxumPath, Request, State},
-    http::{header, HeaderName, HeaderValue, StatusCode},
+    extract::Request,
+    http::{HeaderName, HeaderValue, StatusCode},
     middleware,
     middleware::Next,
-    response::{IntoResponse, Response},
+    response::Response,
     routing::get,
     Router,
 };
-use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt, OpenOptionsMaybeDirExt};
-use cap_std::{
-    fs::{Dir, OpenOptions},
-};
-use tokio_util::io::ReaderStream;
 use tower_http::{
     cors::CorsLayer,
     services::ServeDir,
@@ -62,6 +50,18 @@ fn with_security_headers(mut response: Response) -> Response {
 
 async fn security_headers(request: Request<Body>, next: Next) -> Response {
     with_security_headers(next.run(request).await)
+}
+
+async fn empty_unsatisfiable_range_body(request: Request<Body>, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    if response.status() == StatusCode::RANGE_NOT_SATISFIABLE {
+        response.headers_mut().insert(
+            HeaderName::from_static("content-length"),
+            HeaderValue::from_static("0"),
+        );
+        *response.body_mut() = Body::empty();
+    }
+    response
 }
 
 pub async fn run_webserver(port: Option<u16>) -> anyhow::Result<()> {
@@ -109,12 +109,22 @@ pub fn build_http_router(context: crate::entrypoints::Context) -> anyhow::Result
 
     let (book_download_routes, book_thumbnail_routes) = match book_static_roots {
         Some(roots) => (
-            Router::new()
-                .route("/{*path}", get(serve_book_download))
-                .with_state(RetainedRoot::new(roots.downloads)),
-            Router::new()
-                .route("/{file}", get(serve_book_thumbnail))
-                .with_state(RetainedRoot::new(roots.thumbnails)),
+            Router::new().route_service(
+                "/{*path}",
+                ServeDir::with_backend(
+                    "",
+                    CapabilityBackend::new(roots.downloads, StaticFilePolicy::BookDownload),
+                ),
+            )
+            .layer(middleware::from_fn(empty_unsatisfiable_range_body)),
+            Router::new().route_service(
+                "/{file}",
+                ServeDir::with_backend(
+                    "",
+                    CapabilityBackend::new(roots.thumbnails, StaticFilePolicy::BookThumbnail),
+                ),
+            )
+            .layer(middleware::from_fn(empty_unsatisfiable_range_body)),
         ),
         None => (
             Router::new().route("/{*path}", get(serve_unavailable_book_static)),
@@ -138,160 +148,6 @@ pub fn build_http_router(context: crate::entrypoints::Context) -> anyhow::Result
                 .make_span_with(DefaultMakeSpan::default().include_headers(false)),
         )
         .layer(middleware::from_fn(security_headers)))
-}
-
-#[derive(Clone)]
-struct RetainedRoot {
-    dir: Arc<Dir>,
-}
-
-impl RetainedRoot {
-    fn new(dir: Arc<Dir>) -> Self {
-        Self { dir }
-    }
-}
-
-struct OpenedStaticFile {
-    file: cap_std::fs::File,
-    len: u64,
-}
-
-fn normal_components(path: &str, allow_nested: bool) -> anyhow::Result<Vec<OsString>> {
-    let mut components = Vec::new();
-    for component in Path::new(path).components() {
-        match component {
-            Component::Normal(component) => components.push(component.to_os_string()),
-            Component::CurDir
-            | Component::ParentDir
-            | Component::Prefix(_)
-            | Component::RootDir => return Err(anyhow!("static file path must be relative")),
-        }
-    }
-    if components.is_empty() || (!allow_nested && components.len() != 1) {
-        return Err(anyhow!("static file path has an invalid component count"));
-    }
-    Ok(components)
-}
-
-fn open_regular_file(root: &Dir, components: &[OsString]) -> anyhow::Result<OpenedStaticFile> {
-    let mut current = root.try_clone()?;
-    for component in &components[..components.len() - 1] {
-        let mut options = OpenOptions::new();
-        options
-            .read(true)
-            .maybe_dir(true)
-            .follow(FollowSymlinks::No);
-        let child = current.open_with(Path::new(component), &options)?;
-        if !child.metadata()?.is_dir() {
-            return Err(anyhow!("static file parent is not a directory"));
-        }
-        current = Dir::from_std_file(child.into_std());
-    }
-
-    let mut options = OpenOptions::new();
-    options.read(true).follow(FollowSymlinks::No);
-    let file = current.open_with(
-        Path::new(components.last().expect("validated non-empty components")),
-        &options,
-    )?;
-    let metadata = file.metadata()?;
-    if !metadata.is_file() {
-        return Err(anyhow!("static file is not a regular file"));
-    }
-    Ok(OpenedStaticFile {
-        file,
-        len: metadata.len(),
-    })
-}
-
-fn download_content_type(path: &str) -> anyhow::Result<&'static str> {
-    match Path::new(path)
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("pdf") => Ok("application/pdf"),
-        Some("epub") => Ok("application/epub+zip"),
-        _ => Err(anyhow!("unsupported book download extension")),
-    }
-}
-
-fn thumbnail_content_type(path: &str) -> anyhow::Result<&'static str> {
-    match Path::new(path)
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("jpg") => Ok("image/jpeg"),
-        _ => Err(anyhow!("unsupported book thumbnail extension")),
-    }
-}
-
-async fn stream_static_file(
-    root: RetainedRoot,
-    path: String,
-    allow_nested: bool,
-    content_type: &'static str,
-) -> Response {
-    let open_path = path.clone();
-    let opened = tokio::task::spawn_blocking(move || {
-        let components = normal_components(&open_path, allow_nested)?;
-        open_regular_file(&root.dir, &components)
-    })
-    .await;
-
-    let opened = match opened {
-        Ok(Ok(opened)) => opened,
-        Ok(Err(error)) => {
-            tracing::warn!("Rejected static book file {}: {}", path, error);
-            return StatusCode::NOT_FOUND.into_response();
-        }
-        Err(error) => {
-            tracing::error!("Static book file task failed for {}: {}", path, error);
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    };
-
-    let file = tokio::fs::File::from_std(opened.file.into_std());
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, content_type)
-        .header(header::CONTENT_LENGTH, opened.len)
-        .body(Body::from_stream(ReaderStream::new(file)))
-        .unwrap_or_else(|error| {
-            tracing::error!("Failed to build static book response for {}: {}", path, error);
-            StatusCode::INTERNAL_SERVER_ERROR.into_response()
-        })
-}
-
-async fn serve_book_download(
-    State(root): State<RetainedRoot>,
-    AxumPath(path): AxumPath<String>,
-) -> Response {
-    let content_type = match download_content_type(&path) {
-        Ok(content_type) => content_type,
-        Err(error) => {
-            tracing::warn!("Rejected book download {}: {}", path, error);
-            return StatusCode::NOT_FOUND.into_response();
-        }
-    };
-    stream_static_file(root, path, true, content_type).await
-}
-
-async fn serve_book_thumbnail(
-    State(root): State<RetainedRoot>,
-    AxumPath(file): AxumPath<String>,
-) -> Response {
-    let content_type = match thumbnail_content_type(&file) {
-        Ok(content_type) => content_type,
-        Err(error) => {
-            tracing::warn!("Rejected book thumbnail {}: {}", file, error);
-            return StatusCode::NOT_FOUND.into_response();
-        }
-    };
-    stream_static_file(root, file, false, content_type).await
 }
 
 async fn serve_unavailable_book_static() -> StatusCode {

--- a/tests/book_api_test.rs
+++ b/tests/book_api_test.rs
@@ -525,9 +525,9 @@ async fn serves_nested_book_downloads_from_book_dir() -> Result<()> {
 
 #[tokio::test]
 async fn serves_book_download_byte_ranges() -> Result<()> {
-    let (server, _) = start_server(57212).await?;
+    let (server, _) = start_server(57214).await?;
     let client = reqwest::Client::builder().no_proxy().build()?;
-    let url = "http://localhost:57212/api/books/download/Nonfiction/Programming/static-book.epub";
+    let url = "http://localhost:57214/api/books/download/Nonfiction/Programming/static-book.epub";
     let full_bytes = b"static epub fixture\n";
 
     let full = client.get(url).send().await?;

--- a/tests/book_api_test.rs
+++ b/tests/book_api_test.rs
@@ -23,7 +23,10 @@ use app_lib::{
     },
 };
 use chrono::Local;
-use reqwest::{header::CONTENT_TYPE, Method, StatusCode};
+use reqwest::{
+    header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, RANGE},
+    Method, StatusCode,
+};
 use serde_json::Value;
 use sqlx::{Connection, SqliteConnection};
 use tokio::{fs, task::JoinHandle};
@@ -516,6 +519,43 @@ async fn serves_nested_book_downloads_from_book_dir() -> Result<()> {
         .send()
         .await?;
     assert_eq!(public_response.status(), StatusCode::UNAUTHORIZED);
+
+    Ok(server.abort())
+}
+
+#[tokio::test]
+async fn serves_book_download_byte_ranges() -> Result<()> {
+    let (server, _) = start_server(57212).await?;
+    let client = reqwest::Client::builder().no_proxy().build()?;
+    let url = "http://localhost:57212/api/books/download/Nonfiction/Programming/static-book.epub";
+    let full_bytes = b"static epub fixture\n";
+
+    let full = client.get(url).send().await?;
+    assert_eq!(full.status(), StatusCode::OK);
+    assert_eq!(full.headers()[ACCEPT_RANGES], "bytes");
+    assert_eq!(full.headers()[CONTENT_LENGTH], full_bytes.len().to_string());
+    assert_eq!(full.bytes().await?.as_ref(), full_bytes);
+
+    for (range, expected_content_range, expected) in [
+        ("bytes=1-3", "bytes 1-3/20", &full_bytes[1..=3]),
+        ("bytes=7-", "bytes 7-19/20", &full_bytes[7..]),
+        ("bytes=-8", "bytes 12-19/20", &full_bytes[12..]),
+    ] {
+        let response = client.get(url).header(RANGE, range).send().await?;
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT, "{range}");
+        assert_eq!(response.headers()[ACCEPT_RANGES], "bytes", "{range}");
+        assert_eq!(response.headers()[CONTENT_RANGE], expected_content_range, "{range}");
+        assert_eq!(response.headers()[CONTENT_LENGTH], expected.len().to_string(), "{range}");
+        assert_eq!(response.bytes().await?.as_ref(), expected, "{range}");
+    }
+
+    for range in ["bytes=999-", "bytes=0-1,3-4", "bytes=invalid"] {
+        let response = client.get(url).header(RANGE, range).send().await?;
+        assert_eq!(response.status(), StatusCode::RANGE_NOT_SATISFIABLE, "{range}");
+        assert_eq!(response.headers()[ACCEPT_RANGES], "bytes", "{range}");
+        assert_eq!(response.headers()[CONTENT_RANGE], "bytes */20", "{range}");
+        assert!(response.bytes().await?.is_empty(), "{range}");
+    }
 
     Ok(server.abort())
 }

--- a/tests/book_api_test.rs
+++ b/tests/book_api_test.rs
@@ -7,6 +7,7 @@ use std::{
     io::{Cursor, Write},
     path::{Path, PathBuf},
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::Result;
@@ -24,7 +25,10 @@ use app_lib::{
 };
 use chrono::Local;
 use reqwest::{
-    header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, RANGE},
+    header::{
+        ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, IF_MODIFIED_SINCE, IF_RANGE,
+        IF_UNMODIFIED_SINCE, LAST_MODIFIED, RANGE,
+    },
     Method, StatusCode,
 };
 use serde_json::Value;
@@ -556,6 +560,94 @@ async fn serves_book_download_byte_ranges() -> Result<()> {
         assert_eq!(response.headers()[CONTENT_RANGE], "bytes */20", "{range}");
         assert!(response.bytes().await?.is_empty(), "{range}");
     }
+
+    Ok(server.abort())
+}
+
+#[tokio::test]
+async fn book_download_ignores_ranges_on_head() -> Result<()> {
+    let (server, _) = start_server(57222).await?;
+    let client = reqwest::Client::builder().no_proxy().build()?;
+    let url = "http://localhost:57222/api/books/download/Nonfiction/Programming/static-book.epub";
+    let full_bytes = b"static epub fixture\n";
+
+    let response = client.head(url).header(RANGE, "bytes=1-3").send().await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[ACCEPT_RANGES], "bytes");
+    assert_eq!(response.headers()[CONTENT_LENGTH], full_bytes.len().to_string());
+    assert!(response.headers().get(CONTENT_RANGE).is_none());
+    assert!(response.bytes().await?.is_empty());
+
+    Ok(server.abort())
+}
+
+#[tokio::test]
+async fn book_download_conservatively_ignores_if_range() -> Result<()> {
+    let (server, _) = start_server(57223).await?;
+    let client = reqwest::Client::builder().no_proxy().build()?;
+    let url = "http://localhost:57223/api/books/download/Nonfiction/Programming/static-book.epub";
+    let full_bytes = b"static epub fixture\n";
+
+    let response = client
+        .get(url)
+        .header(RANGE, "bytes=1-3")
+        .header(IF_RANGE, "\"stale-validator\"")
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[ACCEPT_RANGES], "bytes");
+    assert_eq!(response.headers()[CONTENT_LENGTH], full_bytes.len().to_string());
+    assert!(response.headers().get(CONTENT_RANGE).is_none());
+    assert_eq!(response.bytes().await?.as_ref(), full_bytes);
+
+    Ok(server.abort())
+}
+
+#[tokio::test]
+async fn book_download_honors_modification_preconditions() -> Result<()> {
+    let temp_root = TempRoot::new("conditional-download", 57224)?;
+    let book_root = temp_root.0.join("books");
+    let book_thumbnail_root = book_root.join(".thumbnails");
+    let book_path = book_root.join("Test/conditional.epub");
+    fs::create_dir_all(book_path.parent().unwrap()).await?;
+    let full_bytes = b"conditional book fixture";
+    fs::write(&book_path, full_bytes).await?;
+
+    let repository: Repository = Arc::new(SqlRepository::new(":memory:", None).await?);
+    let (server, _) =
+        start_server_with_repository(57224, repository, &book_root, &book_thumbnail_root).await?;
+    let client = reqwest::Client::builder().no_proxy().build()?;
+    let url = "http://localhost:57224/api/books/download/Test/conditional.epub";
+
+    let full = client.get(url).send().await?;
+    assert_eq!(full.status(), StatusCode::OK);
+    let last_modified = full
+        .headers()
+        .get(LAST_MODIFIED)
+        .expect("book response must include Last-Modified")
+        .clone();
+    assert_eq!(full.bytes().await?.as_ref(), full_bytes);
+
+    let not_modified = client
+        .get(url)
+        .header(IF_MODIFIED_SINCE, last_modified.clone())
+        .send()
+        .await?;
+    assert_eq!(not_modified.status(), StatusCode::NOT_MODIFIED);
+    assert!(not_modified.bytes().await?.is_empty());
+
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    fs::write(&book_path, b"updated conditional book fixture").await?;
+
+    let precondition_failed = client
+        .get(url)
+        .header(IF_UNMODIFIED_SINCE, last_modified)
+        .send()
+        .await?;
+    assert_eq!(precondition_failed.status(), StatusCode::PRECONDITION_FAILED);
+    assert!(precondition_failed.bytes().await?.is_empty());
 
     Ok(server.abort())
 }

--- a/tests/book_router_test.rs
+++ b/tests/book_router_test.rs
@@ -351,6 +351,13 @@ async fn book_static_routes_enforce_capability_and_file_type_boundaries() -> Res
         default_book_thumbnail_bytes()
     );
 
+    let directory_response = client
+        .get("http://localhost:57210/api/books/download/Valid")
+        .send()
+        .await?;
+    assert_eq!(directory_response.status(), StatusCode::NOT_FOUND);
+    assert!(directory_response.bytes().await?.is_empty());
+
     assert_rejected_without_leaking(
         client
             .get("http://localhost:57210/api/books/download/Escape/secret.epub")

--- a/tests/openapi_contract_test.rs
+++ b/tests/openapi_contract_test.rs
@@ -1392,6 +1392,12 @@ fn book_download_contract_documents_byte_ranges() {
         .any(|parameter| { parameter["name"] == "Range" && parameter["in"] == "header" }));
 
     let responses = &operation["responses"];
+    for status in ["200", "206", "304", "412", "416"] {
+        assert!(
+            responses.get(status).is_some(),
+            "book download route must document status {status}"
+        );
+    }
     for status in ["200", "206", "416"] {
         let response = resolved(&document, &responses[status]);
         assert_eq!(response["headers"]["Accept-Ranges"]["schema"]["const"], "bytes");
@@ -1399,7 +1405,16 @@ fn book_download_contract_documents_byte_ranges() {
     for status in ["200", "206"] {
         let response = resolved(&document, &responses[status]);
         assert!(response["headers"].get("Content-Length").is_some());
+        assert!(response["headers"].get("Last-Modified").is_some());
     }
+    assert_eq!(
+        responses["304"]["$ref"],
+        "#/components/responses/ServeDirNotModifiedResponse"
+    );
+    assert_eq!(
+        responses["412"]["$ref"],
+        "#/components/responses/ServeDirPreconditionFailedResponse"
+    );
     assert!(resolved(&document, &responses["206"])["headers"]
         .get("Content-Range")
         .is_some());

--- a/tests/openapi_contract_test.rs
+++ b/tests/openapi_contract_test.rs
@@ -310,7 +310,7 @@ fn validate_content_schemas(
 fn allows_empty_response_media_type(path: &str, method: &str, status: &str) -> bool {
     matches!(
         (path, method, status),
-        ("/api/books/download/{path}", "get", "200")
+        ("/api/books/download/{path}", "get", "200" | "206" | "416")
             | ("/api/book-thumbnails/{file}", "get", "200")
             | ("/api/stream/{path}", "get", "200" | "206" | "416")
             | ("/api/stream-audio/{audio_index}/{path}", "get", "200")
@@ -1321,6 +1321,8 @@ fn raw_file_responses_use_openapi_31_binary_media_types() {
     let document = contract();
     for (path, status) in [
         ("/api/books/download/{path}", "200"),
+        ("/api/books/download/{path}", "206"),
+        ("/api/books/download/{path}", "416"),
         ("/api/book-thumbnails/{file}", "200"),
         ("/api/stream/{path}", "200"),
         ("/api/stream/{path}", "206"),
@@ -1378,6 +1380,32 @@ fn serve_dir_contract_documents_runtime_responses_and_headers() {
             .get("Content-Range")
             .is_some());
     }
+}
+
+#[test]
+fn book_download_contract_documents_byte_ranges() {
+    let document = contract();
+    let operation = &document["paths"]["/api/books/download/{path}"]["get"];
+    let parameters = operation["parameters"].as_array().unwrap();
+    assert!(parameters.iter().any(|parameter| {
+        parameter["name"] == "Range" && parameter["in"] == "header"
+    }));
+
+    let responses = &operation["responses"];
+    for status in ["200", "206"] {
+        let response = resolved(&document, &responses[status]);
+        assert_eq!(
+            response["headers"]["Accept-Ranges"]["schema"]["const"],
+            "bytes"
+        );
+        assert!(response["headers"].get("Content-Length").is_some());
+    }
+    assert!(resolved(&document, &responses["206"])["headers"]
+        .get("Content-Range")
+        .is_some());
+    assert!(resolved(&document, &responses["416"])["headers"]
+        .get("Content-Range")
+        .is_some());
 }
 
 #[test]

--- a/tests/openapi_contract_test.rs
+++ b/tests/openapi_contract_test.rs
@@ -1387,17 +1387,17 @@ fn book_download_contract_documents_byte_ranges() {
     let document = contract();
     let operation = &document["paths"]["/api/books/download/{path}"]["get"];
     let parameters = operation["parameters"].as_array().unwrap();
-    assert!(parameters.iter().any(|parameter| {
-        parameter["name"] == "Range" && parameter["in"] == "header"
-    }));
+    assert!(parameters
+        .iter()
+        .any(|parameter| { parameter["name"] == "Range" && parameter["in"] == "header" }));
 
     let responses = &operation["responses"];
+    for status in ["200", "206", "416"] {
+        let response = resolved(&document, &responses[status]);
+        assert_eq!(response["headers"]["Accept-Ranges"]["schema"]["const"], "bytes");
+    }
     for status in ["200", "206"] {
         let response = resolved(&document, &responses[status]);
-        assert_eq!(
-            response["headers"]["Accept-Ranges"]["schema"]["const"],
-            "bytes"
-        );
         assert!(response["headers"].get("Content-Length").is_some());
     }
     assert!(resolved(&document, &responses["206"])["headers"]

--- a/tests/stream_test.rs
+++ b/tests/stream_test.rs
@@ -4,19 +4,25 @@ mod common;
 
 use crate::common::{get_context, get_repository, get_task_manager};
 use anyhow::Result;
-use app_lib::entrypoints::register;
+use app_lib::adaptors::{FileSystemStore, SqlRepository};
+use app_lib::domain::config::{get_movie_dir, get_thumbnail_dir, MOVIE_DIR};
+use app_lib::domain::traits::{FileStorer, Repository};
+use app_lib::entrypoints::{register, webserver::build_http_router};
+use app_lib::services::MediaStore;
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode as AxumStatusCode},
+    routing::get,
+    Router,
+};
 use common::{get_checker, get_pirate_search};
-use axum::{routing::get, Router};
 use reqwest::{
-    header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, RANGE},
+    header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, IF_RANGE, RANGE},
     StatusCode,
 };
 use std::env;
 use std::sync::Arc;
-use app_lib::adaptors::{FileSystemStore, SqlRepository};
-use app_lib::domain::config::{get_movie_dir, get_thumbnail_dir, MOVIE_DIR};
-use app_lib::domain::traits::{FileStorer, Repository};
-use app_lib::services::MediaStore;
+use tower::ServiceExt;
 use tower_http::services::ServeDir;
 
 const TEST_MOVIR_DIR: &str = "tests/fixtures/media_dir";
@@ -79,6 +85,145 @@ async fn test_video_stream_supports_byte_ranges() -> Result<()> {
     }
 
     Ok(server.abort())
+}
+
+#[tokio::test]
+async fn test_video_stream_ignores_ranges_on_head() -> Result<()> {
+    env::set_var(MOVIE_DIR, TEST_MOVIR_DIR);
+
+    let file_storer: FileStorer = Arc::new(FileSystemStore::new(TEST_MOVIR_DIR));
+    let repo: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+    let store = Arc::new(MediaStore::new(file_storer, repo));
+    let searcher = get_pirate_search("torrents_get.json", "pb_search.html").await;
+    let context = get_context(
+        store,
+        searcher,
+        get_task_manager(),
+        get_repository().await,
+        get_checker(),
+    )
+    .await?;
+    let server = common::create_server(context, 57191).await;
+    let client = reqwest::Client::builder().no_proxy().build()?;
+    let url = "http://localhost:57191/api/stream/test.mp4";
+
+    let response = client.head(url).header(RANGE, "bytes=0-9").send().await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[ACCEPT_RANGES], "bytes");
+    assert_eq!(response.headers()[CONTENT_LENGTH], "256");
+    assert!(response.headers().get(CONTENT_RANGE).is_none());
+    assert!(response.bytes().await?.is_empty());
+
+    Ok(server.abort())
+}
+
+#[tokio::test]
+async fn test_video_stream_conservatively_ignores_if_range() -> Result<()> {
+    env::set_var(MOVIE_DIR, TEST_MOVIR_DIR);
+
+    let file_storer: FileStorer = Arc::new(FileSystemStore::new(TEST_MOVIR_DIR));
+    let repo: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+    let store = Arc::new(MediaStore::new(file_storer, repo));
+    let searcher = get_pirate_search("torrents_get.json", "pb_search.html").await;
+    let context = get_context(
+        store,
+        searcher,
+        get_task_manager(),
+        get_repository().await,
+        get_checker(),
+    )
+    .await?;
+    let server = common::create_server(context, 57192).await;
+    let client = reqwest::Client::builder().no_proxy().build()?;
+    let url = "http://localhost:57192/api/stream/test.mp4";
+    let fixture: Vec<u8> = (0_u8..=255).collect();
+
+    let response = client
+        .get(url)
+        .header(RANGE, "bytes=0-9")
+        .header(IF_RANGE, "\"stale-validator\"")
+        .header("X-Real-IP", "8.8.8.8")
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[ACCEPT_RANGES], "bytes");
+    assert_eq!(response.headers()[CONTENT_LENGTH], "256");
+    assert!(response.headers().get(CONTENT_RANGE).is_none());
+    assert_eq!(response.bytes().await?.as_ref(), fixture.as_slice());
+
+    Ok(server.abort())
+}
+
+#[tokio::test]
+async fn test_video_stream_router_preserves_prefix_and_normalizes_ranges() -> Result<()> {
+    env::set_var(MOVIE_DIR, TEST_MOVIR_DIR);
+
+    let file_storer: FileStorer = Arc::new(FileSystemStore::new(TEST_MOVIR_DIR));
+    let repo: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
+    let store = Arc::new(MediaStore::new(file_storer, repo));
+    let searcher = get_pirate_search("torrents_get.json", "pb_search.html").await;
+    let context = get_context(
+        store,
+        searcher,
+        get_task_manager(),
+        get_repository().await,
+        get_checker(),
+    )
+    .await?;
+    let app = build_http_router(context)?;
+    let fixture: Vec<u8> = (0_u8..=255).collect();
+
+    let head = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri("/api/stream/test.mp4")
+                .header("range", "bytes=0-9")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(head.status(), AxumStatusCode::OK);
+    assert_eq!(head.headers()["accept-ranges"], "bytes");
+    assert_eq!(head.headers()["content-length"], "256");
+    assert!(head.headers().get("content-range").is_none());
+    assert!(to_bytes(head.into_body(), usize::MAX).await?.is_empty());
+
+    let if_range = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/stream/test.mp4")
+                .header("range", "bytes=0-9")
+                .header("if-range", "\"stale-validator\"")
+                .header("x-real-ip", "8.8.8.8")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(if_range.status(), AxumStatusCode::OK);
+    assert_eq!(if_range.headers()["content-length"], "256");
+    assert!(if_range.headers().get("content-range").is_none());
+    assert_eq!(
+        to_bytes(if_range.into_body(), usize::MAX).await?.as_ref(),
+        fixture.as_slice()
+    );
+
+    for uri in ["/api/stream", "/api/stream/"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("x-real-ip", "8.8.8.8")
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(response.status(), AxumStatusCode::NOT_FOUND, "{uri}");
+    }
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/tests/stream_test.rs
+++ b/tests/stream_test.rs
@@ -7,7 +7,10 @@ use anyhow::Result;
 use app_lib::entrypoints::register;
 use common::{get_checker, get_pirate_search};
 use axum::{routing::get, Router};
-use reqwest::{header::RANGE, StatusCode};
+use reqwest::{
+    header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, RANGE},
+    StatusCode,
+};
 use std::env;
 use std::sync::Arc;
 use app_lib::adaptors::{FileSystemStore, SqlRepository};
@@ -19,17 +22,13 @@ use tower_http::services::ServeDir;
 const TEST_MOVIR_DIR: &str = "tests/fixtures/media_dir";
 
 #[tokio::test]
-async fn test_video_stream() -> Result<()> {
+async fn test_video_stream_supports_byte_ranges() -> Result<()> {
     env::set_var(MOVIE_DIR, TEST_MOVIR_DIR);
 
     let file_storer: FileStorer = Arc::new(FileSystemStore::new(TEST_MOVIR_DIR));
-
     let repo: Repository = Arc::new(SqlRepository::new(":memory:", None).await.unwrap());
-
     let store = Arc::new(MediaStore::new(file_storer, repo));
-
     let searcher = get_pirate_search("torrents_get.json", "pb_search.html").await;
-
     let context = get_context(
         store,
         searcher,
@@ -37,23 +36,46 @@ async fn test_video_stream() -> Result<()> {
         get_repository().await,
         get_checker(),
     ).await?;
-
     let server = common::create_server(context, 57186).await;
+    let client = reqwest::Client::builder().no_proxy().build()?;
+    let url = "http://localhost:57186/api/stream/test.mp4";
+    let fixture: Vec<u8> = (0_u8..=255).collect();
 
-    let client = reqwest::Client::new();
+    let full = client.get(url).send().await?;
+    assert_eq!(full.status(), StatusCode::OK);
+    assert_eq!(full.headers()[ACCEPT_RANGES], "bytes");
+    assert_eq!(full.headers()[CONTENT_LENGTH], "256");
+    assert_eq!(full.bytes().await?.as_ref(), fixture.as_slice());
 
-    let response = client
-        .get("http://localhost:57186/api/stream/test.mp4")
-        .header(RANGE, "bytes=0-100")
-        .send()
-        .await?;
+    for (range, content_range, expected) in [
+        ("bytes=0-100", "bytes 0-100/256", &fixture[0..=100]),
+        ("bytes=250-", "bytes 250-255/256", &fixture[250..]),
+        ("bytes=-6", "bytes 250-255/256", &fixture[250..]),
+    ] {
+        let response = client.get(url).header(RANGE, range).send().await?;
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT, "{range}");
+        assert_eq!(response.headers()[ACCEPT_RANGES], "bytes", "{range}");
+        assert_eq!(response.headers()[CONTENT_RANGE], content_range, "{range}");
+        assert_eq!(
+            response.headers()[CONTENT_LENGTH],
+            expected.len().to_string(),
+            "{range}"
+        );
+        assert_eq!(response.bytes().await?.as_ref(), expected, "{range}");
+    }
 
-    assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
-
-    let data = response.bytes().await?;
-
-    for c in 0..data.len() {
-        assert_eq!(data[c], c as u8);
+    for range in ["bytes=256-", "bytes=0-1,3-4", "bytes=invalid"] {
+        let response = client.get(url).header(RANGE, range).send().await?;
+        assert_eq!(
+            response.status(),
+            StatusCode::RANGE_NOT_SATISFIABLE,
+            "{range}"
+        );
+        assert_eq!(response.headers()[ACCEPT_RANGES], "bytes", "{range}");
+        assert_eq!(response.headers()[CONTENT_RANGE], "bytes */256", "{range}");
+        if range == "bytes=256-" {
+            assert!(response.bytes().await?.is_empty(), "{range}");
+        }
     }
 
     Ok(server.abort())


### PR DESCRIPTION
Restores EPUB/PDF byte-range responses with tower-http 0.7's pluggable backend while preserving retained-directory, extension, nesting, and no-symlink policies. Adds exact EPUB and video range regression matrices plus OpenAPI coverage.